### PR TITLE
fix(docker): use pnpm exec prisma instead of npx in Dockerfiles

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -52,7 +52,7 @@ RUN pnpm --filter @support-helper/database build
 COPY apps/api/ apps/api/
 
 # Generate Prisma client (this creates node_modules/.prisma and node_modules/@prisma)
-RUN cd apps/api && npx prisma generate
+RUN cd apps/api && pnpm exec prisma generate
 
 # Build the API
 RUN pnpm --filter @support-helper/api build

--- a/apps/worker/Dockerfile
+++ b/apps/worker/Dockerfile
@@ -58,7 +58,7 @@ COPY apps/api/tsconfig.json apps/api/tsconfig.json
 COPY apps/worker/ apps/worker/
 
 # Generate Prisma client for worker (uses api's schema)
-RUN npx prisma@5.22.0 generate --schema=apps/api/prisma/schema.prisma
+RUN pnpm exec prisma generate --schema=apps/api/prisma/schema.prisma
 
 # Build the Worker
 RUN pnpm --filter @support-helper/worker build
@@ -103,9 +103,9 @@ COPY --from=build /app/packages/database/dist packages/database/dist
 # Copy Worker build output
 COPY --from=build /app/apps/worker/dist apps/worker/dist
 
-# Copy Prisma schema and generate client in production context
+# Copy Prisma schema (needed at runtime) and generated client from build
 COPY --from=build /app/apps/api/prisma apps/api/prisma
-RUN npx prisma@5.22.0 generate --schema=apps/api/prisma/schema.prisma
+COPY --from=build /app/node_modules/.prisma ./node_modules/.prisma
 
 # Create non-root user
 RUN groupadd -g 1001 appgroup && \


### PR DESCRIPTION
npx prisma downloads latest Prisma (7.x) which has breaking changes, and npx prisma@5.22.0 fails with "prisma: not found" in Docker slim. Using pnpm exec prisma runs the version already installed by pnpm install from the lockfile. For the worker production stage, copy the generated Prisma client from the build stage instead of re-generating (prisma CLI is a devDependency, unavailable with --prod).

https://claude.ai/code/session_01BMo8PHKHxiJidZpZRDgBrx