### PR TITLE
fix(ci): remove continue-on-error from test jobs (US-008)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,12 +104,10 @@ jobs:
 
       - name: Run integration tests
         if: matrix.node-version == 20
-        continue-on-error: true
         run: pnpm --filter @support-helper/api test:e2e
 
       - name: Collect coverage
         if: matrix.node-version == 20
-        continue-on-error: true
         run: pnpm test:coverage
 
       - name: Upload coverage to Codecov
@@ -118,7 +116,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: unittests
-          fail_ci_if_error: false
+          fail_ci_if_error: true
 
   build:
     name: Build

--- a/reports/US-006-007-008-ROLLBACK-ANALYSIS-REPORT.md
+++ b/reports/US-006-007-008-ROLLBACK-ANALYSIS-REPORT.md
@@ -1,0 +1,40 @@
+# US-006, US-007, US-008 Rollback Analysis & Completion Report
+
+**Date:** 2026-02-13
+**Status:** ✅ Complete
+**GitHub Issues:** #7 (US-006), #8 (US-007), #9 (US-008)
+
+## Executive Summary
+
+- **US-006 (Rate Limiting)**: ✅ Rollback already completed correctly
+- **US-007 (Database Backups)**: ✅ Rollback already completed correctly  
+- **US-008 (CI continue-on-error)**: ✅ Fixed and completed
+
+Only US-008 required action.
+
+## US-008 Changes
+
+### .github/workflows/ci.yml
+
+1. Removed `continue-on-error: true` from integration tests (line 107)
+2. Removed `continue-on-error: true` from coverage collection (line 112)
+3. Changed `fail_ci_if_error: false` to `true` (line 121)
+
+## Impact
+
+**Before:** Tests could fail silently, broken code could merge
+**After:** CI fails on test failures, enforces code quality
+
+## Acceptance Criteria
+
+| Criterion | Status |
+|-----------|--------|
+| Remove continue-on-error from test jobs | ✅ Done |
+| Change fail_ci_if_error to true | ✅ Done |
+| CI fails if tests fail | ✅ Done |
+
+## Sign-off
+
+**Status:** ✅ Complete
+**Date:** 2026-02-13
+**Delivered by:** Forge Multi-Agent System


### PR DESCRIPTION
## Summary
Remove `continue-on-error` flags from CI test jobs to ensure tests must pass before merging.

## Changes
- ✅ Removed `continue-on-error: true` from integration tests
- ✅ Removed `continue-on-error: true` from coverage collection  
- ✅ Changed `fail_ci_if_error: false` to `true` in Codecov upload

## Impact
**Before:** Tests could fail silently without blocking merges
**After:** CI fails immediately if tests fail, enforcing code quality

## Acceptance Criteria
- [x] Remove `continue-on-error` from test jobs
- [x] Change `fail_ci_if_error` to true
- [x] CI fails if tests fail
- [x] CI fails if coverage upload fails

## Files Changed
- `.github/workflows/ci.yml` - CI configuration
- `reports/US-006-007-008-ROLLBACK-ANALYSIS-REPORT.md` - Implementation report

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)