### PR TITLE
feat(api): implement auto-response to client after resolution (US-5.3)

### DIFF
--- a/apps/api/prisma/migrations/20260216160000_add_ticket_messages_and_reopen_token/migration.sql
+++ b/apps/api/prisma/migrations/20260216160000_add_ticket_messages_and_reopen_token/migration.sql
@@ -1,0 +1,28 @@
+-- AlterTable
+ALTER TABLE "tickets" ADD COLUMN "reopen_token" VARCHAR(255);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "tickets_reopen_token_key" ON "tickets"("reopen_token");
+
+-- CreateTable
+CREATE TABLE "ticket_messages" (
+    "id" UUID NOT NULL DEFAULT uuid_generate_v4(),
+    "ticket_id" UUID NOT NULL,
+    "type" VARCHAR(50) NOT NULL,
+    "content" TEXT NOT NULL,
+    "sender" VARCHAR(255) NOT NULL,
+    "metadata" JSONB DEFAULT '{}',
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ticket_messages_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "ticket_messages_ticket_id_idx" ON "ticket_messages"("ticket_id");
+
+-- CreateIndex
+CREATE INDEX "ticket_messages_ticket_id_created_at_idx" ON "ticket_messages"("ticket_id", "created_at");
+
+-- AddForeignKey
+ALTER TABLE "ticket_messages" ADD CONSTRAINT "ticket_messages_ticket_id_fkey" FOREIGN KEY ("ticket_id") REFERENCES "tickets"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -115,6 +115,9 @@ model Ticket {
   // Public tracking
   publicId           String?   @unique @map("public_id") @db.VarChar(20)
 
+  // Resolution
+  reopenToken        String?   @unique @map("reopen_token") @db.VarChar(255)
+
   // Assignment
   assignedTo         String?   @map("assigned_to") @db.Uuid
   assignedAt         DateTime? @map("assigned_at")
@@ -136,6 +139,7 @@ model Ticket {
   agentTasks           AgentTask[]
   ticketEvents         TicketEvent[]
   notificationLogs     NotificationLog[]
+  ticketMessages       TicketMessage[]
 
   @@index([tenantId])
   @@index([applicationId])
@@ -497,6 +501,12 @@ model AgentTask {
   prUrl           String?   @map("pr_url") @db.Text
   branchName      String?   @map("branch_name") @db.VarChar(255)
 
+  // Review tracking (US-3.4)
+  reviewRequestedAt DateTime? @map("review_requested_at")
+  reviewedAt        DateTime? @map("reviewed_at")
+  reviewedBy        String?   @map("reviewed_by") @db.VarChar(255)
+  rejectionReason   String?   @map("rejection_reason") @db.Text
+
   createdAt       DateTime  @default(now()) @map("created_at")
   updatedAt       DateTime  @updatedAt @map("updated_at")
 
@@ -571,4 +581,25 @@ model NotificationLog {
   @@index([tenantId])
   @@index([status])
   @@map("notification_logs")
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// TICKET MESSAGES
+// ═══════════════════════════════════════════════════════════════════════
+
+model TicketMessage {
+  id        String   @id @default(dbgenerated("uuid_generate_v4()")) @db.Uuid
+  ticketId  String   @map("ticket_id") @db.Uuid
+  type      String   @db.VarChar(50) // system, user, agent
+  content   String   @db.Text
+  sender    String   @db.VarChar(255)
+  metadata  Json?    @default("{}")
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
+
+  ticket Ticket @relation(fields: [ticketId], references: [id], onDelete: Cascade)
+
+  @@index([ticketId])
+  @@index([ticketId, createdAt])
+  @@map("ticket_messages")
 }

--- a/apps/api/src/modules/notifications/notification.processor.ts
+++ b/apps/api/src/modules/notifications/notification.processor.ts
@@ -303,6 +303,7 @@ export class NotificationProcessor extends WorkerHost {
       pr_created: `PR Created: ${title}`,
       pr_merged: `PR Merged: ${title}`,
       fix_deployed: `Fix Deployed: ${title}`,
+      ticket_resolved: `Your issue has been resolved: ${title}`,
     };
     return eventLabels[eventType] || `Ticket Update: ${title}`;
   }
@@ -311,6 +312,10 @@ export class NotificationProcessor extends WorkerHost {
     eventType: string,
     data: Record<string, any>,
   ): string {
+    if (eventType === 'ticket_resolved') {
+      return this.buildResolutionEmailHtml(data);
+    }
+
     const title = data.ticketTitle || data.title || 'Ticket Update';
     const summary = data.summary || data.description || '';
     const emoji = this.getEventEmoji(eventType);
@@ -348,6 +353,82 @@ export class NotificationProcessor extends WorkerHost {
 </html>`.trim();
   }
 
+  private buildResolutionEmailHtml(data: Record<string, any>): string {
+    const title = data.ticketTitle || data.title || 'Your reported issue';
+    const summary = data.summary || '';
+    const changes: string[] = Array.isArray(data.changes) ? data.changes : [];
+    const reopenToken = data.reopenToken || '';
+    const ticketId = data.ticketId || '';
+    const prUrl = data.prUrl || '';
+
+    const apiUrl =
+      this.configService.get<string>('API_URL') ||
+      this.configService.get<string>('api.url') ||
+      'http://localhost:3001';
+
+    const reopenUrl = reopenToken
+      ? `${apiUrl}/api/sdk/tickets/${ticketId}/reopen?token=${reopenToken}`
+      : '';
+
+    const changesHtml = changes.length > 0
+      ? `<ul style="padding-left: 20px; margin: 12px 0;">${changes.map((c) => `<li style="margin-bottom: 4px;">${this.escapeHtml(c)}</li>`).join('')}</ul>`
+      : '';
+
+    const prSection = prUrl
+      ? `<p style="margin-top: 12px;"><a href="${this.escapeHtml(prUrl)}" style="color: #4F46E5; text-decoration: underline;">View the code changes</a></p>`
+      : '';
+
+    const reopenSection = reopenUrl
+      ? `
+      <div style="margin-top: 24px; padding: 16px; background: #FEF3C7; border-radius: 8px; border: 1px solid #FCD34D;">
+        <p style="margin: 0 0 8px 0; font-weight: 600; color: #92400E;">Still having this problem?</p>
+        <p style="margin: 0 0 12px 0; color: #78350F; font-size: 14px;">If the issue persists, you can reopen this ticket and our team will investigate further.</p>
+        <a href="${this.escapeHtml(reopenUrl)}" style="display: inline-block; background: #F59E0B; color: #78350F; padding: 8px 16px; border-radius: 6px; text-decoration: none; font-weight: 500;">Reopen Ticket</a>
+      </div>`
+      : '';
+
+    return `
+<!DOCTYPE html>
+<html>
+<head>
+  <style>
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; line-height: 1.6; color: #333; }
+    .container { max-width: 600px; margin: 0 auto; padding: 20px; }
+    .header { background: #059669; color: white; padding: 20px; border-radius: 8px 8px 0 0; }
+    .content { background: #f9fafb; padding: 20px; border: 1px solid #e5e7eb; border-top: none; border-radius: 0 0 8px 8px; }
+    .footer { margin-top: 20px; font-size: 12px; color: #6b7280; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <div class="header">
+      <h2 style="margin: 0;">Your issue has been resolved</h2>
+    </div>
+    <div class="content">
+      <h3 style="margin-top: 0;">${this.escapeHtml(title)}</h3>
+      ${summary ? `<p>${this.escapeHtml(summary)}</p>` : ''}
+      ${changesHtml ? `<h4 style="margin-bottom: 4px;">What changed:</h4>${changesHtml}` : ''}
+      ${prSection}
+      ${reopenSection}
+      <div class="footer">
+        <p>Ticket ID: ${ticketId}</p>
+        <p>This is an automated notification from Support Helper.</p>
+      </div>
+    </div>
+  </div>
+</body>
+</html>`.trim();
+  }
+
+  private escapeHtml(text: string): string {
+    return text
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#039;');
+  }
+
   private formatEventType(eventType: string): string {
     return eventType
       .split('_')
@@ -363,6 +444,7 @@ export class NotificationProcessor extends WorkerHost {
       pr_created: '🔀',
       pr_merged: '✅',
       fix_deployed: '🚀',
+      ticket_resolved: '🎉',
     };
     return emojis[eventType] || '📋';
   }

--- a/apps/api/src/modules/tickets/controllers/ticket-reopen.controller.ts
+++ b/apps/api/src/modules/tickets/controllers/ticket-reopen.controller.ts
@@ -1,0 +1,117 @@
+import {
+  Controller,
+  Post,
+  Param,
+  Query,
+  NotFoundException,
+  BadRequestException,
+  Logger,
+} from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiParam,
+  ApiQuery,
+  ApiResponse,
+} from '@nestjs/swagger';
+import { Throttle } from '@nestjs/throttler';
+import { Public } from '../../../common/decorators/public.decorator';
+import { PrismaService } from '../../../prisma/prisma.service';
+
+@ApiTags('Ticket Reopen')
+@Controller('sdk/tickets')
+export class TicketReopenController {
+  private readonly logger = new Logger(TicketReopenController.name);
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  @Post(':id/reopen')
+  @Public()
+  @Throttle({ public: { limit: 5, ttl: 60000 } })
+  @ApiOperation({
+    summary: 'Reopen a resolved ticket (public, token-based auth)',
+  })
+  @ApiParam({ name: 'id', description: 'Ticket ID', type: 'string' })
+  @ApiQuery({ name: 'token', description: 'Reopen token', type: 'string' })
+  @ApiResponse({ status: 200, description: 'Ticket reopened successfully' })
+  @ApiResponse({ status: 400, description: 'Missing or invalid token' })
+  @ApiResponse({ status: 404, description: 'Ticket not found or token mismatch' })
+  async reopen(
+    @Param('id') id: string,
+    @Query('token') token: string,
+  ) {
+    if (!token) {
+      throw new BadRequestException('Token is required');
+    }
+
+    // Look up ticket by id and validate reopenToken
+    const ticket = await this.prisma.ticket.findUnique({
+      where: { id },
+      select: {
+        id: true,
+        reopenToken: true,
+        status: true,
+        tenantId: true,
+      },
+    });
+
+    if (!ticket || ticket.reopenToken !== token) {
+      throw new NotFoundException(
+        'Ticket not found or reopen token is invalid',
+      );
+    }
+
+    // Only allow reopening merged/resolved/closed tickets
+    const reopenableStatuses = ['merged', 'resolved', 'closed'];
+    if (!reopenableStatuses.includes(ticket.status)) {
+      throw new BadRequestException(
+        `Ticket is currently "${ticket.status}" and cannot be reopened`,
+      );
+    }
+
+    // Reopen the ticket
+    await this.prisma.$transaction([
+      // Update ticket status
+      this.prisma.ticket.update({
+        where: { id },
+        data: {
+          status: 'open',
+          reopenToken: null, // Invalidate the token after use
+          resolvedAt: null,
+        },
+      }),
+      // Create a ticket message recording the reopen
+      this.prisma.ticketMessage.create({
+        data: {
+          ticketId: id,
+          type: 'user',
+          content: 'Client reports issue persists after resolution.',
+          sender: 'client',
+          metadata: {
+            reopenedAt: new Date().toISOString(),
+            previousStatus: ticket.status,
+          },
+        },
+      }),
+      // Record timeline event
+      this.prisma.ticketEvent.create({
+        data: {
+          ticketId: id,
+          tenantId: ticket.tenantId,
+          eventType: 'ticket_reopened',
+          data: {
+            previousStatus: ticket.status,
+            reason: 'Client reports issue persists',
+          },
+        },
+      }),
+    ]);
+
+    this.logger.log(`Ticket ${id} reopened by client via reopen token`);
+
+    return {
+      success: true,
+      message: 'Ticket reopened. Our team has been notified and will follow up.',
+    };
+  }
+}

--- a/apps/api/src/modules/tickets/schemas/ticket.schema.ts
+++ b/apps/api/src/modules/tickets/schemas/ticket.schema.ts
@@ -9,6 +9,7 @@ export const TICKET_STATUSES = [
   'in_progress',
   'pending',
   'resolved',
+  'merged',
   'closed',
 ] as const;
 

--- a/apps/api/src/modules/tickets/services/auto-response.service.ts
+++ b/apps/api/src/modules/tickets/services/auto-response.service.ts
@@ -1,0 +1,152 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { randomUUID } from 'crypto';
+import { PrismaService } from '../../../prisma/prisma.service';
+import { NotificationService } from '../../notifications/notification.service';
+import { TicketTimelineService } from './ticket-timeline.service';
+import {
+  ResolutionSummaryService,
+  PrDetails,
+} from './resolution-summary.service';
+
+@Injectable()
+export class AutoResponseService {
+  private readonly logger = new Logger(AutoResponseService.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly resolutionSummaryService: ResolutionSummaryService,
+    private readonly notificationService: NotificationService,
+    private readonly ticketTimelineService: TicketTimelineService,
+  ) {}
+
+  /**
+   * Handle ticket status change to "merged":
+   * 1. Generate AI resolution summary
+   * 2. Store a TicketMessage
+   * 3. Generate reopenToken
+   * 4. Dispatch notification with resolution email
+   * 5. Record timeline event
+   */
+  async handleTicketMerged(
+    ticketId: string,
+    tenantId: string,
+    prDetails?: PrDetails,
+  ): Promise<void> {
+    this.logger.log(
+      `Handling merged status for ticket ${ticketId} in tenant ${tenantId}`,
+    );
+
+    // 1. Fetch ticket details
+    const ticket = await this.prisma.ticket.findFirst({
+      where: { id: ticketId, tenantId },
+      include: {
+        application: { select: { id: true, name: true } },
+        agentTasks: {
+          orderBy: { updatedAt: 'desc' },
+          take: 1,
+          select: {
+            prNumber: true,
+            prUrl: true,
+            branchName: true,
+          },
+        },
+      },
+    });
+
+    if (!ticket) {
+      this.logger.warn(`Ticket ${ticketId} not found for tenant ${tenantId}`);
+      return;
+    }
+
+    // Merge PR details from agent task if not provided
+    const mergedPrDetails: PrDetails = {
+      ...prDetails,
+      prNumber:
+        prDetails?.prNumber ?? ticket.agentTasks[0]?.prNumber ?? undefined,
+      prUrl: prDetails?.prUrl ?? ticket.agentTasks[0]?.prUrl ?? undefined,
+      branchName:
+        prDetails?.branchName ??
+        ticket.agentTasks[0]?.branchName ??
+        undefined,
+    };
+
+    // 2. Generate resolution summary
+    const summary =
+      await this.resolutionSummaryService.generateResolutionSummary(
+        ticket,
+        mergedPrDetails,
+      );
+
+    this.logger.log(
+      `Generated resolution summary for ticket ${ticketId}: ${summary.summary.substring(0, 80)}...`,
+    );
+
+    // 3. Generate reopen token and save to ticket
+    const reopenToken = randomUUID();
+    await this.prisma.ticket.update({
+      where: { id: ticketId },
+      data: { reopenToken },
+    });
+
+    // 4. Store ticket message
+    await this.prisma.ticketMessage.create({
+      data: {
+        ticketId,
+        type: 'system',
+        content: summary.summary,
+        sender: 'ai-agent',
+        metadata: {
+          changes: summary.changes,
+          version: summary.version,
+          prNumber: mergedPrDetails.prNumber,
+          prUrl: mergedPrDetails.prUrl,
+          branchName: mergedPrDetails.branchName,
+          generatedAt: new Date().toISOString(),
+        } as any,
+      },
+    });
+
+    // 5. Dispatch notification (email with resolution summary + reopen link)
+    try {
+      await this.notificationService.dispatchNotification({
+        ticketId,
+        tenantId,
+        applicationId: ticket.applicationId,
+        eventType: 'ticket_resolved',
+        data: {
+          ticketId,
+          ticketTitle: ticket.title,
+          summary: summary.summary,
+          changes: summary.changes,
+          version: summary.version,
+          reopenToken,
+          publicId: ticket.publicId,
+          prUrl: mergedPrDetails.prUrl,
+          prNumber: mergedPrDetails.prNumber,
+        },
+      });
+    } catch (err) {
+      this.logger.warn(
+        `Failed to dispatch resolution notification for ticket ${ticketId}: ${
+          err instanceof Error ? err.message : 'Unknown'
+        }`,
+      );
+    }
+
+    // 6. Record timeline event
+    await this.ticketTimelineService.recordEvent(
+      ticketId,
+      tenantId,
+      'resolution_sent',
+      {
+        summary: summary.summary,
+        changes: summary.changes,
+        reopenTokenGenerated: true,
+      },
+    );
+
+    this.logger.log(
+      `Auto-response completed for ticket ${ticketId}`,
+    );
+  }
+}

--- a/apps/api/src/modules/tickets/services/resolution-summary.service.ts
+++ b/apps/api/src/modules/tickets/services/resolution-summary.service.ts
@@ -1,0 +1,124 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { AIService } from '../../../ai/ai.service';
+
+export interface ResolutionSummary {
+  summary: string;
+  changes: string[];
+  version?: string;
+}
+
+export interface PrDetails {
+  prNumber?: number;
+  prUrl?: string;
+  branchName?: string;
+  title?: string;
+  body?: string;
+}
+
+@Injectable()
+export class ResolutionSummaryService {
+  private readonly logger = new Logger(ResolutionSummaryService.name);
+
+  constructor(private readonly aiService: AIService) {}
+
+  /**
+   * Generate a client-friendly resolution summary using AI.
+   * Falls back to a simple template if AI is unavailable.
+   */
+  async generateResolutionSummary(
+    ticket: {
+      id: string;
+      title?: string | null;
+      description?: string | null;
+      type?: string | null;
+      severity?: string | null;
+    },
+    prDetails?: PrDetails,
+  ): Promise<ResolutionSummary> {
+    const prompt = this.buildPrompt(ticket, prDetails);
+
+    try {
+      const response = await this.aiService.generateCompletion(prompt);
+
+      if (!response) {
+        return this.getFallbackSummary(ticket, prDetails);
+      }
+
+      // Try parsing as JSON
+      const jsonMatch = response.match(/\{[\s\S]*\}/);
+      if (jsonMatch) {
+        const parsed = JSON.parse(jsonMatch[0]);
+        return {
+          summary:
+            parsed.summary ||
+            `The issue "${ticket.title || 'reported'}" has been resolved.`,
+          changes: Array.isArray(parsed.changes) ? parsed.changes : [],
+          version: parsed.version || undefined,
+        };
+      }
+
+      // If not JSON, use the raw text as summary
+      return {
+        summary: response.trim(),
+        changes: [],
+      };
+    } catch (error) {
+      this.logger.warn(
+        `Failed to generate AI resolution summary for ticket ${ticket.id}: ${
+          error instanceof Error ? error.message : 'Unknown error'
+        }`,
+      );
+      return this.getFallbackSummary(ticket, prDetails);
+    }
+  }
+
+  private buildPrompt(
+    ticket: {
+      title?: string | null;
+      description?: string | null;
+      type?: string | null;
+      severity?: string | null;
+    },
+    prDetails?: PrDetails,
+  ): string {
+    return `Given this bug report and the code changes made, explain in simple, non-technical terms what was fixed and where. Be friendly and concise.
+
+Bug Report:
+- Title: ${ticket.title || 'N/A'}
+- Description: ${ticket.description || 'N/A'}
+- Type: ${ticket.type || 'N/A'}
+- Severity: ${ticket.severity || 'N/A'}
+
+${
+  prDetails
+    ? `Code Changes (PR):
+- PR Title: ${prDetails.title || 'N/A'}
+- Branch: ${prDetails.branchName || 'N/A'}
+- Description: ${prDetails.body || 'N/A'}`
+    : 'No PR details available.'
+}
+
+Respond with a JSON object containing:
+- summary: A friendly 2-3 sentence explanation for the end user
+- changes: An array of 1-3 bullet points describing what changed
+- version: The version number if mentioned, otherwise omit
+
+Respond ONLY with valid JSON.`;
+  }
+
+  private getFallbackSummary(
+    ticket: {
+      title?: string | null;
+      description?: string | null;
+    },
+    prDetails?: PrDetails,
+  ): ResolutionSummary {
+    const title = ticket.title || 'your reported issue';
+    return {
+      summary: `Good news! The issue "${title}" has been resolved. Our team has reviewed the problem and applied a fix that should address the behavior you reported.`,
+      changes: prDetails?.title
+        ? [`Fix applied: ${prDetails.title}`]
+        : ['A fix has been applied to resolve the reported issue.'],
+    };
+  }
+}

--- a/apps/api/src/modules/tickets/services/ticket-timeline.service.ts
+++ b/apps/api/src/modules/tickets/services/ticket-timeline.service.ts
@@ -11,6 +11,7 @@ const NOTIFIABLE_EVENTS = new Set([
   'pr_created',
   'pr_merged',
   'fix_deployed',
+  'ticket_resolved',
 ]);
 
 export interface TimelineEntry {

--- a/apps/api/src/modules/tickets/ticket-tracking.controller.ts
+++ b/apps/api/src/modules/tickets/ticket-tracking.controller.ts
@@ -54,6 +54,8 @@ export class TicketTrackingController {
       'agent_analysis_started',
       'agent_plan_ready',
       'agent_plan_approved',
+      'resolution_sent',
+      'ticket_reopened',
     ];
 
     const filteredEvents = ticket.ticketEvents.filter((e) =>

--- a/apps/api/src/modules/tickets/tickets.module.ts
+++ b/apps/api/src/modules/tickets/tickets.module.ts
@@ -4,10 +4,13 @@ import { TicketsService } from './tickets.service';
 import { TicketsSearchService } from './tickets-search.service';
 import { TicketsAIService } from './tickets-ai.service';
 import { TicketTimelineService } from './services/ticket-timeline.service';
+import { ResolutionSummaryService } from './services/resolution-summary.service';
+import { AutoResponseService } from './services/auto-response.service';
 import { TicketsGateway } from './tickets.gateway';
 import { TicketsController } from './tickets.controller';
 import { SdkTicketsController } from './sdk-tickets.controller';
 import { TicketTrackingController } from './ticket-tracking.controller';
+import { TicketReopenController } from './controllers/ticket-reopen.controller';
 import { PrismaModule } from '../../prisma/prisma.module';
 import { AIModule } from '../../ai/ai.module';
 import { AuthModule } from '../../auth/auth.module';
@@ -39,8 +42,24 @@ import { WsJwtGuard } from '../agent/ws-jwt.guard';
       name: 'github',
     }),
   ],
-  controllers: [TicketsController, SdkTicketsController, TicketTrackingController],
-  providers: [TicketsService, TicketsSearchService, TicketsAIService, TicketTimelineService, TicketsGateway, WsJwtGuard],
-  exports: [TicketsService, TicketsSearchService, TicketsAIService, TicketTimelineService, TicketsGateway],
+  controllers: [TicketsController, SdkTicketsController, TicketTrackingController, TicketReopenController],
+  providers: [
+    TicketsService,
+    TicketsSearchService,
+    TicketsAIService,
+    TicketTimelineService,
+    ResolutionSummaryService,
+    AutoResponseService,
+    TicketsGateway,
+    WsJwtGuard,
+  ],
+  exports: [
+    TicketsService,
+    TicketsSearchService,
+    TicketsAIService,
+    TicketTimelineService,
+    AutoResponseService,
+    TicketsGateway,
+  ],
 })
 export class TicketsModule {}

--- a/apps/api/src/modules/tickets/tickets.service.ts
+++ b/apps/api/src/modules/tickets/tickets.service.ts
@@ -6,6 +6,7 @@ import {
   Inject,
   Logger,
   forwardRef,
+  Optional,
 } from '@nestjs/common';
 import { InjectQueue } from '@nestjs/bullmq';
 import { Queue } from 'bullmq';
@@ -14,6 +15,7 @@ import { PrismaService } from '../../prisma/prisma.service';
 import { CreateTicketDto, UpdateTicketDto, FilterTicketsDto, BulkTicketDto } from './dto';
 import { TicketsGateway } from './tickets.gateway';
 import { CacheService, CacheKeys, CacheTTL } from '../../cache';
+import { AutoResponseService } from './services/auto-response.service';
 import { Prisma } from '@prisma/client';
 
 @Injectable()
@@ -26,6 +28,9 @@ export class TicketsService {
     private readonly ticketsGateway: TicketsGateway,
     private readonly cacheService: CacheService,
     @InjectQueue('github') private readonly githubQueue: Queue,
+    @Optional()
+    @Inject(forwardRef(() => AutoResponseService))
+    private readonly autoResponseService?: AutoResponseService,
   ) {}
 
   /**
@@ -311,8 +316,8 @@ export class TicketsService {
       }),
     };
 
-    // Update resolvedAt if status changed to resolved
-    if (dto.status === 'resolved') {
+    // Update resolvedAt if status changed to resolved or merged
+    if (dto.status === 'resolved' || dto.status === 'merged') {
       data.resolvedAt = new Date();
     } else if (dto.status) {
       data.resolvedAt = null;
@@ -347,6 +352,17 @@ export class TicketsService {
       this.enqueueGithubStatusSync(ticketId, dto.status).catch((err) => {
         this.logger.warn(`Failed to enqueue GitHub status sync for ticket ${ticketId}: ${err.message}`);
       });
+    }
+
+    // Auto-response: when status changes to "merged", generate summary and notify client
+    if (dto.status === 'merged' && this.autoResponseService) {
+      this.autoResponseService
+        .handleTicketMerged(ticketId, tenantId)
+        .catch((err) => {
+          this.logger.warn(
+            `Failed to trigger auto-response for ticket ${ticketId}: ${err instanceof Error ? err.message : 'Unknown'}`,
+          );
+        });
     }
 
     return result;


### PR DESCRIPTION
## Summary
- **US-5.3**: Automatic response to client after ticket resolution (PR merged → AI summary → email → reopen option)
- Add `TicketMessage` model and `reopenToken` field to `Ticket` (Prisma migration)
- Create `ResolutionSummaryService`: AI-powered friendly resolution summaries via Claude API
- Create `AutoResponseService`: orchestrates summary generation, email dispatch, message storage, and timeline events on ticket merge
- Create `TicketReopenController`: public `POST /api/sdk/tickets/:id/reopen` with token-based auth (single-use)
- Wire auto-response trigger in `TicketsService.update()` when status → `merged`
- Add `ticket_resolved` email template with resolution summary and reopen link
- Update notification processor with resolution email support and HTML escaping
- Add `resolution_sent` and `ticket_reopened` to customer-facing timeline events

Closes #60

## Test plan
- [ ] Verify migration applies cleanly (`pnpm db:migrate`)
- [ ] Test auto-response triggers when ticket status changes to `merged`
- [ ] Test AI summary generation via `ResolutionSummaryService`
- [ ] Test email template rendering with resolution summary
- [ ] Test reopen endpoint with valid/invalid/expired tokens
- [ ] Verify timeline events appear for resolution_sent and ticket_reopened

🤖 Generated with [Claude Code](https://claude.com/claude-code)