### PR TITLE
feat(api,web): auto-response to client after ticket resolution (US-5.3)

### DIFF
--- a/apps/api/prisma/migrations/20260216200000_add_ticket_messages_and_reopen_token/migration.sql
+++ b/apps/api/prisma/migrations/20260216200000_add_ticket_messages_and_reopen_token/migration.sql
@@ -1,0 +1,28 @@
+-- AlterTable
+ALTER TABLE "tickets" ADD COLUMN "reopen_token" VARCHAR(255);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "tickets_reopen_token_key" ON "tickets"("reopen_token");
+
+-- CreateTable
+CREATE TABLE "ticket_messages" (
+    "id" UUID NOT NULL DEFAULT uuid_generate_v4(),
+    "ticket_id" UUID NOT NULL,
+    "type" VARCHAR(50) NOT NULL,
+    "content" TEXT NOT NULL,
+    "sender" VARCHAR(255) NOT NULL,
+    "metadata" JSONB DEFAULT '{}',
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ticket_messages_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "ticket_messages_ticket_id_idx" ON "ticket_messages"("ticket_id");
+
+-- CreateIndex
+CREATE INDEX "ticket_messages_ticket_id_created_at_idx" ON "ticket_messages"("ticket_id", "created_at");
+
+-- AddForeignKey
+ALTER TABLE "ticket_messages" ADD CONSTRAINT "ticket_messages_ticket_id_fkey" FOREIGN KEY ("ticket_id") REFERENCES "tickets"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -114,6 +114,7 @@ model Ticket {
 
   // Public tracking
   publicId           String?   @unique @map("public_id") @db.VarChar(20)
+  reopenToken        String?   @unique @map("reopen_token") @db.VarChar(255)
 
   // Assignment
   assignedTo         String?   @map("assigned_to") @db.Uuid
@@ -136,6 +137,7 @@ model Ticket {
   agentTasks           AgentTask[]
   ticketEvents         TicketEvent[]
   notificationLogs     NotificationLog[]
+  ticketMessages       TicketMessage[]
 
   @@index([tenantId])
   @@index([applicationId])
@@ -577,4 +579,25 @@ model NotificationLog {
   @@index([tenantId])
   @@index([status])
   @@map("notification_logs")
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// TICKET MESSAGES
+// ═══════════════════════════════════════════════════════════════════════
+
+model TicketMessage {
+  id        String   @id @default(dbgenerated("uuid_generate_v4()")) @db.Uuid
+  ticketId  String   @map("ticket_id") @db.Uuid
+  type      String   @db.VarChar(50) // "system", "user", "agent"
+  content   String   @db.Text
+  sender    String   @db.VarChar(255)
+  metadata  Json?    @default("{}")
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
+
+  ticket Ticket @relation(fields: [ticketId], references: [id], onDelete: Cascade)
+
+  @@index([ticketId])
+  @@index([ticketId, createdAt])
+  @@map("ticket_messages")
 }

--- a/apps/api/src/modules/github/services/auto-merge.service.ts
+++ b/apps/api/src/modules/github/services/auto-merge.service.ts
@@ -1,7 +1,8 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, Optional, Inject } from '@nestjs/common';
 import { PrismaService } from '../../../prisma/prisma.service';
 import { GithubAppService } from './github-app.service';
 import { TicketTimelineService } from '../../tickets/services/ticket-timeline.service';
+import { AutoResponseService } from '../../tickets/services/auto-response.service';
 
 export interface MergeResult {
   merged: boolean;
@@ -16,6 +17,9 @@ export class AutoMergeService {
     private readonly prisma: PrismaService,
     private readonly githubAppService: GithubAppService,
     private readonly ticketTimelineService: TicketTimelineService,
+    @Optional()
+    @Inject(AutoResponseService)
+    private readonly autoResponseService?: AutoResponseService,
   ) {}
 
   /**
@@ -242,6 +246,19 @@ export class AutoMergeService {
       },
     );
 
+    // Trigger auto-response to client
+    if (this.autoResponseService) {
+      await this.autoResponseService.handleTicketMerged(
+        agentTask.ticketId,
+        agentTask.tenantId,
+        {
+          prNumber,
+          prUrl: agentTask.prUrl,
+          branchName: agentTask.branchName,
+        },
+      );
+    }
+
     this.logger.log(
       `Handled PR merged: ${owner}/${repo}#${prNumber} — ticket ${agentTask.ticketId} updated to merged`,
     );
@@ -304,6 +321,19 @@ export class AutoMergeService {
         prUrl: agentTask.prUrl,
       },
     );
+
+    // Trigger auto-response to client
+    if (this.autoResponseService) {
+      await this.autoResponseService.handleTicketMerged(
+        agentTask.ticketId,
+        tenantId,
+        {
+          prNumber,
+          prUrl: agentTask.prUrl,
+          branchName,
+        },
+      );
+    }
 
     this.logger.log(
       `Updated AgentTask ${agentTask.id} and ticket ${agentTask.ticketId} to merged`,

--- a/apps/api/src/modules/notifications/notification.processor.ts
+++ b/apps/api/src/modules/notifications/notification.processor.ts
@@ -303,6 +303,7 @@ export class NotificationProcessor extends WorkerHost {
       pr_created: `PR Created: ${title}`,
       pr_merged: `PR Merged: ${title}`,
       fix_deployed: `Fix Deployed: ${title}`,
+      ticket_resolved: `Your issue has been resolved: ${title}`,
     };
     return eventLabels[eventType] || `Ticket Update: ${title}`;
   }
@@ -311,6 +312,11 @@ export class NotificationProcessor extends WorkerHost {
     eventType: string,
     data: Record<string, any>,
   ): string {
+    // Special template for ticket_resolved event
+    if (eventType === 'ticket_resolved') {
+      return this.buildResolutionEmailHtml(data);
+    }
+
     const title = data.ticketTitle || data.title || 'Ticket Update';
     const summary = data.summary || data.description || '';
     const emoji = this.getEventEmoji(eventType);
@@ -335,9 +341,9 @@ export class NotificationProcessor extends WorkerHost {
       <h2 style="margin: 0;">${emoji} ${eventLabel}</h2>
     </div>
     <div class="content">
-      <h3>${title}</h3>
+      <h3>${this.escapeHtml(title)}</h3>
       <span class="event-badge">${eventType}</span>
-      ${summary ? `<p>${summary}</p>` : ''}
+      ${summary ? `<p>${this.escapeHtml(summary)}</p>` : ''}
       <div class="footer">
         <p>Ticket ID: ${data.ticketId || 'N/A'}</p>
         <p>This is an automated notification from Support Helper.</p>
@@ -346,6 +352,111 @@ export class NotificationProcessor extends WorkerHost {
   </div>
 </body>
 </html>`.trim();
+  }
+
+  private buildResolutionEmailHtml(data: Record<string, any>): string {
+    const title = data.ticketTitle || 'Your Issue';
+    const summary = data.summary || 'Your issue has been resolved.';
+    const changes = Array.isArray(data.changes) ? data.changes : [];
+    const version = data.version || 'the next release';
+    const reopenToken = data.reopenToken || '';
+    const ticketId = data.ticketId || '';
+    const prUrl = data.prUrl || '';
+    const publicId = data.publicId || '';
+
+    // Build API base URL from config or use default
+    const apiUrl = this.configService.get<string>('API_URL') || 'http://localhost:3001';
+    const trackingUrl = publicId ? `${apiUrl}/tickets/track/${publicId}` : '';
+    const reopenUrl = ticketId && reopenToken ? `${apiUrl}/api/sdk/tickets/${ticketId}/reopen?token=${reopenToken}` : '';
+
+    const changesListHtml = changes.length > 0
+      ? `<ul style="margin: 16px 0; padding-left: 20px;">
+          ${changes.map((change: string) => `<li>${this.escapeHtml(change)}</li>`).join('')}
+        </ul>`
+      : '';
+
+    return `
+<!DOCTYPE html>
+<html>
+<head>
+  <style>
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; line-height: 1.6; color: #333; }
+    .container { max-width: 600px; margin: 0 auto; padding: 20px; }
+    .header { background: #10B981; color: white; padding: 20px; border-radius: 8px 8px 0 0; text-align: center; }
+    .content { background: #f9fafb; padding: 30px; border: 1px solid #e5e7eb; border-top: none; }
+    .summary { background: white; padding: 20px; border-radius: 8px; margin: 20px 0; border-left: 4px solid #10B981; }
+    .changes-section { margin: 20px 0; }
+    .changes-section h4 { margin-top: 0; color: #374151; }
+    .version-badge { display: inline-block; background: #EEF2FF; color: #4F46E5; padding: 6px 12px; border-radius: 16px; font-size: 13px; font-weight: 500; }
+    .button-group { margin: 30px 0; text-align: center; }
+    .button { display: inline-block; padding: 12px 24px; margin: 0 8px; border-radius: 6px; text-decoration: none; font-weight: 500; transition: all 0.2s; }
+    .button-primary { background: #4F46E5; color: white; }
+    .button-primary:hover { background: #4338CA; }
+    .button-secondary { background: white; color: #4F46E5; border: 2px solid #4F46E5; }
+    .button-secondary:hover { background: #EEF2FF; }
+    .footer { margin-top: 30px; padding-top: 20px; border-top: 1px solid #e5e7eb; font-size: 12px; color: #6b7280; text-align: center; }
+    ul { line-height: 1.8; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <div class="header">
+      <h2 style="margin: 0; font-size: 28px;">🎉 Your Issue Has Been Resolved!</h2>
+    </div>
+    <div class="content">
+      <h3 style="margin-top: 0; color: #111827;">${this.escapeHtml(title)}</h3>
+
+      <div class="summary">
+        <p style="margin: 0; font-size: 16px;">${this.escapeHtml(summary)}</p>
+      </div>
+
+      ${changesListHtml ? `
+      <div class="changes-section">
+        <h4>What's been fixed:</h4>
+        ${changesListHtml}
+      </div>
+      ` : ''}
+
+      <p style="margin: 20px 0;">
+        <strong>Expected in:</strong> <span class="version-badge">${this.escapeHtml(version)}</span>
+      </p>
+
+      ${prUrl ? `
+      <p style="margin: 16px 0;">
+        <a href="${this.escapeHtml(prUrl)}" style="color: #4F46E5; text-decoration: none;">View the pull request →</a>
+      </p>
+      ` : ''}
+
+      <div class="button-group">
+        ${trackingUrl ? `
+        <a href="${this.escapeHtml(trackingUrl)}" class="button button-primary">Track Your Issue</a>
+        ` : ''}
+        ${reopenUrl ? `
+        <a href="${this.escapeHtml(reopenUrl)}" class="button button-secondary">Issue Still Exists?</a>
+        ` : ''}
+      </div>
+
+      <div class="footer">
+        <p><strong>Ticket ID:</strong> ${ticketId}</p>
+        ${publicId ? `<p><strong>Tracking ID:</strong> ${publicId}</p>` : ''}
+        <p>This is an automated notification from Support Helper.</p>
+        <p style="margin-top: 12px; font-size: 11px;">If the issue persists after the fix is deployed, click the "Issue Still Exists?" button to reopen the ticket.</p>
+      </div>
+    </div>
+  </div>
+</body>
+</html>`.trim();
+  }
+
+  private escapeHtml(text: string): string {
+    const map: Record<string, string> = {
+      '&': '&amp;',
+      '<': '&lt;',
+      '>': '&gt;',
+      '"': '&quot;',
+      "'": '&#039;',
+    };
+    return text.replace(/[&<>"']/g, (m) => map[m]);
   }
 
   private formatEventType(eventType: string): string {
@@ -363,6 +474,7 @@ export class NotificationProcessor extends WorkerHost {
       pr_created: '🔀',
       pr_merged: '✅',
       fix_deployed: '🚀',
+      ticket_resolved: '🎉',
     };
     return emojis[eventType] || '📋';
   }

--- a/apps/api/src/modules/tickets/controllers/ticket-reopen.controller.ts
+++ b/apps/api/src/modules/tickets/controllers/ticket-reopen.controller.ts
@@ -1,0 +1,99 @@
+import {
+  Controller,
+  Post,
+  Param,
+  Query,
+  BadRequestException,
+  NotFoundException,
+  Logger,
+} from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiParam, ApiQuery, ApiResponse } from '@nestjs/swagger';
+import { Throttle } from '@nestjs/throttler';
+import { PrismaService } from '../../../prisma/prisma.service';
+import { TicketTimelineService } from '../services/ticket-timeline.service';
+
+@ApiTags('Ticket Reopen')
+@Controller('sdk/tickets')
+export class TicketReopenController {
+  private readonly logger = new Logger(TicketReopenController.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly ticketTimelineService: TicketTimelineService,
+  ) {}
+
+  @Post(':id/reopen')
+  @Throttle({ default: { limit: 5, ttl: 60000 } })
+  @ApiOperation({ summary: 'Reopen a resolved ticket (public, token-based)' })
+  @ApiParam({ name: 'id', description: 'Ticket ID' })
+  @ApiQuery({ name: 'token', description: 'Reopen token from the resolution email' })
+  @ApiResponse({ status: 200, description: 'Ticket reopened successfully' })
+  @ApiResponse({ status: 400, description: 'Invalid or expired token' })
+  @ApiResponse({ status: 404, description: 'Ticket not found' })
+  async reopen(
+    @Param('id') id: string,
+    @Query('token') token: string,
+  ) {
+    if (!token) {
+      throw new BadRequestException('Reopen token is required');
+    }
+
+    // 1. Find ticket and validate token
+    const ticket = await this.prisma.ticket.findUnique({
+      where: { id },
+    });
+
+    if (!ticket) {
+      throw new NotFoundException('Ticket not found');
+    }
+
+    if (ticket.reopenToken !== token) {
+      throw new BadRequestException('Invalid or expired reopen token');
+    }
+
+    // 2. Check status is reopenable
+    const reopenableStatuses = ['merged', 'resolved', 'closed'];
+    if (!reopenableStatuses.includes(ticket.status)) {
+      throw new BadRequestException(
+        `Ticket cannot be reopened from status "${ticket.status}"`,
+      );
+    }
+
+    // 3. Update ticket: reopen and clear token
+    await this.prisma.$transaction([
+      this.prisma.ticket.update({
+        where: { id },
+        data: {
+          status: 'open',
+          reopenToken: null,
+          resolvedAt: null,
+        },
+      }),
+      this.prisma.ticketMessage.create({
+        data: {
+          ticketId: id,
+          type: 'user',
+          content: 'Client reports the issue persists after resolution.',
+          sender: 'client',
+        },
+      }),
+    ]);
+
+    // 4. Record timeline event
+    await this.ticketTimelineService.recordEvent(
+      id,
+      ticket.tenantId,
+      'ticket_reopened',
+      { previousStatus: ticket.status },
+    );
+
+    this.logger.log(`Ticket ${id} reopened by client`);
+
+    return {
+      success: true,
+      ticketId: id,
+      status: 'open',
+      message: 'Your ticket has been reopened. Our team will look into it.',
+    };
+  }
+}

--- a/apps/api/src/modules/tickets/services/auto-response.service.ts
+++ b/apps/api/src/modules/tickets/services/auto-response.service.ts
@@ -1,0 +1,135 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { randomUUID } from 'crypto';
+import { PrismaService } from '../../../prisma/prisma.service';
+import { ResolutionSummaryService } from './resolution-summary.service';
+import { TicketTimelineService } from './ticket-timeline.service';
+import { NotificationService } from '../../notifications/notification.service';
+
+export interface PrDetails {
+  prNumber: number;
+  prUrl: string | null;
+  branchName: string | null;
+}
+
+@Injectable()
+export class AutoResponseService {
+  private readonly logger = new Logger(AutoResponseService.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly resolutionSummaryService: ResolutionSummaryService,
+    private readonly ticketTimelineService: TicketTimelineService,
+    private readonly notificationService: NotificationService,
+  ) {}
+
+  async handleTicketMerged(
+    ticketId: string,
+    tenantId: string,
+    prDetails?: PrDetails,
+  ): Promise<void> {
+    try {
+      // 1. Fetch ticket with agent tasks
+      const ticket = await this.prisma.ticket.findUnique({
+        where: { id: ticketId },
+        include: {
+          agentTasks: {
+            orderBy: { createdAt: 'desc' },
+            take: 1,
+          },
+        },
+      });
+
+      if (!ticket) {
+        this.logger.warn(`Ticket ${ticketId} not found for auto-response`);
+        return;
+      }
+
+      // 2. Build PR details from agent task if not provided
+      const effectivePrDetails: PrDetails | undefined = prDetails || (
+        ticket.agentTasks[0]
+          ? {
+              prNumber: ticket.agentTasks[0].prNumber || 0,
+              prUrl: ticket.agentTasks[0].prUrl,
+              branchName: ticket.agentTasks[0].branchName,
+            }
+          : undefined
+      );
+
+      // 3. Generate AI resolution summary
+      const resolutionSummary = await this.resolutionSummaryService.generateResolutionSummary(
+        {
+          id: ticket.id,
+          title: ticket.title,
+          description: ticket.description,
+          type: ticket.type,
+          severity: ticket.severity,
+        },
+        effectivePrDetails,
+      );
+
+      // 4. Generate reopen token
+      const reopenToken = randomUUID();
+
+      // 5. Save reopen token + create TicketMessage
+      await this.prisma.$transaction([
+        this.prisma.ticket.update({
+          where: { id: ticketId },
+          data: { reopenToken },
+        }),
+        this.prisma.ticketMessage.create({
+          data: {
+            ticketId,
+            type: 'system',
+            content: resolutionSummary.summary,
+            sender: 'system',
+            metadata: {
+              changes: resolutionSummary.changes,
+              version: resolutionSummary.version,
+              prDetails: effectivePrDetails ? {
+                prNumber: effectivePrDetails.prNumber,
+                prUrl: effectivePrDetails.prUrl,
+                branchName: effectivePrDetails.branchName,
+              } : undefined,
+            } as any,
+          },
+        }),
+      ]);
+
+      // 6. Dispatch notification
+      await this.notificationService.dispatchNotification({
+        ticketId,
+        tenantId,
+        applicationId: ticket.applicationId,
+        eventType: 'ticket_resolved',
+        data: {
+          ticketId,
+          ticketTitle: ticket.title,
+          publicId: ticket.publicId,
+          summary: resolutionSummary.summary,
+          changes: resolutionSummary.changes,
+          version: resolutionSummary.version,
+          reopenToken,
+          prUrl: effectivePrDetails?.prUrl,
+          prNumber: effectivePrDetails?.prNumber,
+        },
+      });
+
+      // 7. Record timeline event
+      await this.ticketTimelineService.recordEvent(
+        ticketId,
+        tenantId,
+        'resolution_sent',
+        {
+          summary: resolutionSummary.summary,
+          changes: resolutionSummary.changes,
+        },
+      );
+
+      this.logger.log(`Auto-response sent for ticket ${ticketId}`);
+    } catch (error) {
+      this.logger.error(
+        `Failed to send auto-response for ticket ${ticketId}: ${error instanceof Error ? error.message : 'Unknown'}`,
+      );
+    }
+  }
+}

--- a/apps/api/src/modules/tickets/services/resolution-summary.service.ts
+++ b/apps/api/src/modules/tickets/services/resolution-summary.service.ts
@@ -1,0 +1,90 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { AIService } from '../../../ai/ai.service';
+
+export interface ResolutionSummary {
+  summary: string;
+  changes: string[];
+  version?: string;
+}
+
+interface TicketInfo {
+  id: string;
+  title: string | null;
+  description: string | null;
+  type: string | null;
+  severity: string | null;
+}
+
+interface PrDetails {
+  prNumber: number;
+  prUrl: string | null;
+  branchName: string | null;
+  title?: string;
+  body?: string;
+}
+
+@Injectable()
+export class ResolutionSummaryService {
+  private readonly logger = new Logger(ResolutionSummaryService.name);
+
+  constructor(private readonly aiService: AIService) {}
+
+  async generateResolutionSummary(
+    ticket: TicketInfo,
+    prDetails?: PrDetails,
+  ): Promise<ResolutionSummary> {
+    const prompt = `You are a technical support assistant. A bug report has been fixed and the fix has been merged.
+Generate a client-friendly resolution summary. Explain in simple terms what was fixed, without technical jargon.
+
+Bug Report Title: ${ticket.title || 'N/A'}
+Bug Report Description: ${ticket.description || 'N/A'}
+Issue Type: ${ticket.type || 'N/A'}
+Severity: ${ticket.severity || 'N/A'}
+${prDetails ? `
+PR Number: #${prDetails.prNumber}
+PR URL: ${prDetails.prUrl || 'N/A'}
+Branch: ${prDetails.branchName || 'N/A'}
+` : ''}
+
+Respond with a JSON object:
+{
+  "summary": "A 2-3 sentence summary for the client explaining what was fixed",
+  "changes": ["Key change 1", "Key change 2"],
+  "version": "next release"
+}
+
+Respond ONLY with valid JSON.`;
+
+    try {
+      const response = await this.aiService.generateCompletion(prompt);
+
+      if (!response) {
+        return this.getFallbackSummary(ticket);
+      }
+
+      const jsonMatch = response.match(/\{[\s\S]*\}/);
+      if (!jsonMatch) {
+        return this.getFallbackSummary(ticket);
+      }
+
+      const parsed = JSON.parse(jsonMatch[0]);
+      return {
+        summary: parsed.summary || this.getFallbackSummary(ticket).summary,
+        changes: Array.isArray(parsed.changes) ? parsed.changes : [],
+        version: parsed.version,
+      };
+    } catch (error) {
+      this.logger.warn(
+        `Failed to generate AI resolution summary for ticket ${ticket.id}: ${error instanceof Error ? error.message : 'Unknown'}`,
+      );
+      return this.getFallbackSummary(ticket);
+    }
+  }
+
+  private getFallbackSummary(ticket: TicketInfo): ResolutionSummary {
+    return {
+      summary: `Your reported issue "${ticket.title || 'Bug Report'}" has been fixed. The fix has been merged and will be available in the next release.`,
+      changes: ['The reported issue has been addressed'],
+    };
+  }
+}

--- a/apps/api/src/modules/tickets/services/ticket-timeline.service.ts
+++ b/apps/api/src/modules/tickets/services/ticket-timeline.service.ts
@@ -11,6 +11,8 @@ const NOTIFIABLE_EVENTS = new Set([
   'pr_created',
   'pr_merged',
   'fix_deployed',
+  'resolution_sent',
+  'ticket_reopened',
 ]);
 
 export interface TimelineEntry {

--- a/apps/api/src/modules/tickets/ticket-tracking.controller.ts
+++ b/apps/api/src/modules/tickets/ticket-tracking.controller.ts
@@ -54,6 +54,8 @@ export class TicketTrackingController {
       'agent_analysis_started',
       'agent_plan_ready',
       'agent_plan_approved',
+      'resolution_sent',
+      'ticket_reopened',
     ];
 
     const filteredEvents = ticket.ticketEvents.filter((e) =>

--- a/apps/api/src/modules/tickets/tickets.module.ts
+++ b/apps/api/src/modules/tickets/tickets.module.ts
@@ -4,10 +4,13 @@ import { TicketsService } from './tickets.service';
 import { TicketsSearchService } from './tickets-search.service';
 import { TicketsAIService } from './tickets-ai.service';
 import { TicketTimelineService } from './services/ticket-timeline.service';
+import { ResolutionSummaryService } from './services/resolution-summary.service';
+import { AutoResponseService } from './services/auto-response.service';
 import { TicketsGateway } from './tickets.gateway';
 import { TicketsController } from './tickets.controller';
 import { SdkTicketsController } from './sdk-tickets.controller';
 import { TicketTrackingController } from './ticket-tracking.controller';
+import { TicketReopenController } from './controllers/ticket-reopen.controller';
 import { PrismaModule } from '../../prisma/prisma.module';
 import { AIModule } from '../../ai/ai.module';
 import { AuthModule } from '../../auth/auth.module';
@@ -39,8 +42,8 @@ import { WsJwtGuard } from '../agent/ws-jwt.guard';
       name: 'github',
     }),
   ],
-  controllers: [TicketsController, SdkTicketsController, TicketTrackingController],
-  providers: [TicketsService, TicketsSearchService, TicketsAIService, TicketTimelineService, TicketsGateway, WsJwtGuard],
-  exports: [TicketsService, TicketsSearchService, TicketsAIService, TicketTimelineService, TicketsGateway],
+  controllers: [TicketsController, SdkTicketsController, TicketTrackingController, TicketReopenController],
+  providers: [TicketsService, TicketsSearchService, TicketsAIService, TicketTimelineService, ResolutionSummaryService, AutoResponseService, TicketsGateway, WsJwtGuard],
+  exports: [TicketsService, TicketsSearchService, TicketsAIService, TicketTimelineService, ResolutionSummaryService, AutoResponseService, TicketsGateway],
 })
 export class TicketsModule {}

--- a/apps/api/test/unit/controllers/ticket-reopen.controller.spec.ts
+++ b/apps/api/test/unit/controllers/ticket-reopen.controller.spec.ts
@@ -1,0 +1,117 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { TicketReopenController } from '../../../src/modules/tickets/controllers/ticket-reopen.controller';
+import { TicketTimelineService } from '../../../src/modules/tickets/services/ticket-timeline.service';
+import { PrismaService } from '../../../src/prisma/prisma.service';
+
+describe('TicketReopenController', () => {
+  let controller: TicketReopenController;
+  let prismaService: PrismaService;
+  let ticketTimelineService: TicketTimelineService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [TicketReopenController],
+      providers: [
+        {
+          provide: PrismaService,
+          useValue: {
+            ticket: {
+              findUnique: jest.fn(),
+              update: jest.fn(),
+            },
+            ticketMessage: {
+              create: jest.fn(),
+            },
+            $transaction: jest.fn(),
+          },
+        },
+        {
+          provide: TicketTimelineService,
+          useValue: {
+            recordEvent: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    controller = module.get<TicketReopenController>(TicketReopenController);
+    prismaService = module.get<PrismaService>(PrismaService);
+    ticketTimelineService = module.get<TicketTimelineService>(TicketTimelineService);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('reopen', () => {
+    const mockTicket = {
+      id: 'ticket-123',
+      tenantId: 'tenant-123',
+      status: 'merged',
+      reopenToken: 'valid-token-123',
+    };
+
+    it('should reopen ticket with valid token', async () => {
+      jest.spyOn(prismaService.ticket, 'findUnique').mockResolvedValue(mockTicket as any);
+      jest.spyOn(prismaService, '$transaction').mockResolvedValue([null, null] as any);
+      jest.spyOn(ticketTimelineService, 'recordEvent').mockResolvedValue(undefined);
+
+      const result = await controller.reopen('ticket-123', 'valid-token-123');
+
+      expect(result.success).toBe(true);
+      expect(result.ticketId).toBe('ticket-123');
+      expect(result.status).toBe('open');
+      expect(prismaService.$transaction).toHaveBeenCalled();
+      expect(ticketTimelineService.recordEvent).toHaveBeenCalledWith(
+        'ticket-123',
+        'tenant-123',
+        'ticket_reopened',
+        { previousStatus: 'merged' },
+      );
+    });
+
+    it('should throw BadRequestException when token is missing', async () => {
+      await expect(controller.reopen('ticket-123', '')).rejects.toThrow(BadRequestException);
+    });
+
+    it('should throw NotFoundException when ticket not found', async () => {
+      jest.spyOn(prismaService.ticket, 'findUnique').mockResolvedValue(null);
+
+      await expect(controller.reopen('ticket-123', 'any-token')).rejects.toThrow(NotFoundException);
+    });
+
+    it('should throw BadRequestException when token is invalid', async () => {
+      jest.spyOn(prismaService.ticket, 'findUnique').mockResolvedValue(mockTicket as any);
+
+      await expect(controller.reopen('ticket-123', 'wrong-token')).rejects.toThrow(BadRequestException);
+    });
+
+    it('should throw BadRequestException when ticket is not reopenable', async () => {
+      const newTicket = { ...mockTicket, status: 'new' };
+      jest.spyOn(prismaService.ticket, 'findUnique').mockResolvedValue(newTicket as any);
+
+      await expect(controller.reopen('ticket-123', 'valid-token-123')).rejects.toThrow(BadRequestException);
+    });
+
+    it('should allow reopening from resolved status', async () => {
+      const resolvedTicket = { ...mockTicket, status: 'resolved' };
+      jest.spyOn(prismaService.ticket, 'findUnique').mockResolvedValue(resolvedTicket as any);
+      jest.spyOn(prismaService, '$transaction').mockResolvedValue([null, null] as any);
+
+      const result = await controller.reopen('ticket-123', 'valid-token-123');
+
+      expect(result.success).toBe(true);
+    });
+
+    it('should allow reopening from closed status', async () => {
+      const closedTicket = { ...mockTicket, status: 'closed' };
+      jest.spyOn(prismaService.ticket, 'findUnique').mockResolvedValue(closedTicket as any);
+      jest.spyOn(prismaService, '$transaction').mockResolvedValue([null, null] as any);
+
+      const result = await controller.reopen('ticket-123', 'valid-token-123');
+
+      expect(result.success).toBe(true);
+    });
+  });
+});

--- a/apps/api/test/unit/services/auto-response.service.spec.ts
+++ b/apps/api/test/unit/services/auto-response.service.spec.ts
@@ -1,0 +1,173 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AutoResponseService } from '../../../src/modules/tickets/services/auto-response.service';
+import { ResolutionSummaryService } from '../../../src/modules/tickets/services/resolution-summary.service';
+import { TicketTimelineService } from '../../../src/modules/tickets/services/ticket-timeline.service';
+import { NotificationService } from '../../../src/modules/notifications/notification.service';
+import { PrismaService } from '../../../src/prisma/prisma.service';
+
+describe('AutoResponseService', () => {
+  let service: AutoResponseService;
+  let prismaService: PrismaService;
+  let resolutionSummaryService: ResolutionSummaryService;
+  let ticketTimelineService: TicketTimelineService;
+  let notificationService: NotificationService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AutoResponseService,
+        {
+          provide: PrismaService,
+          useValue: {
+            ticket: {
+              findUnique: jest.fn(),
+              update: jest.fn(),
+            },
+            ticketMessage: {
+              create: jest.fn(),
+            },
+            $transaction: jest.fn(),
+          },
+        },
+        {
+          provide: ResolutionSummaryService,
+          useValue: {
+            generateResolutionSummary: jest.fn(),
+          },
+        },
+        {
+          provide: TicketTimelineService,
+          useValue: {
+            recordEvent: jest.fn(),
+          },
+        },
+        {
+          provide: NotificationService,
+          useValue: {
+            dispatchNotification: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<AutoResponseService>(AutoResponseService);
+    prismaService = module.get<PrismaService>(PrismaService);
+    resolutionSummaryService = module.get<ResolutionSummaryService>(ResolutionSummaryService);
+    ticketTimelineService = module.get<TicketTimelineService>(TicketTimelineService);
+    notificationService = module.get<NotificationService>(NotificationService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('handleTicketMerged', () => {
+    const mockTicket = {
+      id: 'ticket-123',
+      tenantId: 'tenant-123',
+      applicationId: 'app-123',
+      title: 'Login issue',
+      description: 'Cannot login',
+      type: 'bug',
+      severity: 'high',
+      publicId: 'PUB123',
+      agentTasks: [
+        {
+          prNumber: 42,
+          prUrl: 'https://github.com/org/repo/pull/42',
+          branchName: 'fix/login',
+        },
+      ],
+    };
+
+    const mockSummary = {
+      summary: 'Fixed login issue',
+      changes: ['Updated auth flow'],
+      version: 'v1.2.0',
+    };
+
+    it('should handle ticket merged successfully', async () => {
+      jest.spyOn(prismaService.ticket, 'findUnique').mockResolvedValue(mockTicket as any);
+      jest.spyOn(resolutionSummaryService, 'generateResolutionSummary').mockResolvedValue(mockSummary);
+      jest.spyOn(prismaService, '$transaction').mockResolvedValue([null, null] as any);
+      jest.spyOn(notificationService, 'dispatchNotification').mockResolvedValue(undefined);
+      jest.spyOn(ticketTimelineService, 'recordEvent').mockResolvedValue(undefined);
+
+      await service.handleTicketMerged('ticket-123', 'tenant-123');
+
+      expect(prismaService.ticket.findUnique).toHaveBeenCalledWith({
+        where: { id: 'ticket-123' },
+        include: {
+          agentTasks: {
+            orderBy: { createdAt: 'desc' },
+            take: 1,
+          },
+        },
+      });
+
+      expect(resolutionSummaryService.generateResolutionSummary).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'ticket-123',
+          title: 'Login issue',
+        }),
+        expect.objectContaining({
+          prNumber: 42,
+        }),
+      );
+
+      expect(prismaService.$transaction).toHaveBeenCalled();
+      expect(notificationService.dispatchNotification).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ticketId: 'ticket-123',
+          tenantId: 'tenant-123',
+          eventType: 'ticket_resolved',
+        }),
+      );
+      expect(ticketTimelineService.recordEvent).toHaveBeenCalledWith(
+        'ticket-123',
+        'tenant-123',
+        'resolution_sent',
+        expect.any(Object),
+      );
+    });
+
+    it('should handle ticket not found gracefully', async () => {
+      jest.spyOn(prismaService.ticket, 'findUnique').mockResolvedValue(null);
+
+      await service.handleTicketMerged('nonexistent', 'tenant-123');
+
+      expect(resolutionSummaryService.generateResolutionSummary).not.toHaveBeenCalled();
+      expect(prismaService.$transaction).not.toHaveBeenCalled();
+    });
+
+    it('should use provided PR details if passed', async () => {
+      jest.spyOn(prismaService.ticket, 'findUnique').mockResolvedValue({
+        ...mockTicket,
+        agentTasks: [],
+      } as any);
+      jest.spyOn(resolutionSummaryService, 'generateResolutionSummary').mockResolvedValue(mockSummary);
+      jest.spyOn(prismaService, '$transaction').mockResolvedValue([null, null] as any);
+
+      const prDetails = {
+        prNumber: 99,
+        prUrl: 'https://github.com/org/repo/pull/99',
+        branchName: 'custom-branch',
+      };
+
+      await service.handleTicketMerged('ticket-123', 'tenant-123', prDetails);
+
+      expect(resolutionSummaryService.generateResolutionSummary).toHaveBeenCalledWith(
+        expect.any(Object),
+        prDetails,
+      );
+    });
+
+    it('should handle errors gracefully', async () => {
+      jest.spyOn(prismaService.ticket, 'findUnique').mockRejectedValue(new Error('DB error'));
+
+      await expect(
+        service.handleTicketMerged('ticket-123', 'tenant-123'),
+      ).resolves.not.toThrow();
+    });
+  });
+});

--- a/apps/api/test/unit/services/resolution-summary.service.spec.ts
+++ b/apps/api/test/unit/services/resolution-summary.service.spec.ts
@@ -1,0 +1,97 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ResolutionSummaryService } from '../../../src/modules/tickets/services/resolution-summary.service';
+import { AIService } from '../../../src/ai/ai.service';
+
+describe('ResolutionSummaryService', () => {
+  let service: ResolutionSummaryService;
+  let aiService: AIService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ResolutionSummaryService,
+        {
+          provide: AIService,
+          useValue: {
+            generateCompletion: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<ResolutionSummaryService>(ResolutionSummaryService);
+    aiService = module.get<AIService>(AIService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('generateResolutionSummary', () => {
+    const mockTicket = {
+      id: 'ticket-123',
+      title: 'Login button not working',
+      description: 'User cannot click login button',
+      type: 'bug',
+      severity: 'high',
+    };
+
+    const mockPrDetails = {
+      prNumber: 42,
+      prUrl: 'https://github.com/org/repo/pull/42',
+      branchName: 'fix/login-button',
+    };
+
+    it('should generate summary from AI response', async () => {
+      const mockAIResponse = JSON.stringify({
+        summary: 'Fixed the login button issue',
+        changes: ['Updated button click handler', 'Added error logging'],
+        version: 'v1.2.0',
+      });
+
+      jest.spyOn(aiService, 'generateCompletion').mockResolvedValue(mockAIResponse);
+
+      const result = await service.generateResolutionSummary(mockTicket, mockPrDetails);
+
+      expect(result.summary).toBe('Fixed the login button issue');
+      expect(result.changes).toEqual(['Updated button click handler', 'Added error logging']);
+      expect(result.version).toBe('v1.2.0');
+      expect(aiService.generateCompletion).toHaveBeenCalledWith(
+        expect.stringContaining('Login button not working'),
+      );
+    });
+
+    it('should return fallback summary on AI failure', async () => {
+      jest.spyOn(aiService, 'generateCompletion').mockResolvedValue('');
+
+      const result = await service.generateResolutionSummary(mockTicket);
+
+      expect(result.summary).toContain('Login button not working');
+      expect(result.summary).toContain('has been fixed');
+      expect(result.changes).toEqual(['The reported issue has been addressed']);
+    });
+
+    it('should handle invalid JSON response', async () => {
+      jest.spyOn(aiService, 'generateCompletion').mockResolvedValue('Invalid JSON');
+
+      const result = await service.generateResolutionSummary(mockTicket);
+
+      expect(result.summary).toContain('has been fixed');
+      expect(result.changes).toEqual(['The reported issue has been addressed']);
+    });
+
+    it('should work without PR details', async () => {
+      const mockAIResponse = JSON.stringify({
+        summary: 'Issue resolved',
+        changes: ['Fixed'],
+      });
+
+      jest.spyOn(aiService, 'generateCompletion').mockResolvedValue(mockAIResponse);
+
+      const result = await service.generateResolutionSummary(mockTicket);
+
+      expect(result.summary).toBe('Issue resolved');
+      expect(aiService.generateCompletion).toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/web/src/app/track/[publicId]/page.tsx
+++ b/apps/web/src/app/track/[publicId]/page.tsx
@@ -11,6 +11,8 @@ import {
   FileText,
   CircleDot,
   AlertTriangle,
+  Mail,
+  RotateCcw,
 } from 'lucide-react';
 import { formatDistanceToNow } from 'date-fns';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -54,6 +56,8 @@ const EVENT_LABELS: Record<string, string> = {
   pr_created: 'Fix ready for review',
   pr_merged: 'Fix deployed',
   fix_deployed: 'Issue resolved',
+  resolution_sent: 'Resolution notification sent',
+  ticket_reopened: 'Ticket reopened',
 };
 
 function getEventIcon(eventType: string) {
@@ -77,6 +81,10 @@ function getEventIcon(eventType: string) {
       return GitMerge;
     case 'fix_deployed':
       return Rocket;
+    case 'resolution_sent':
+      return Mail;
+    case 'ticket_reopened':
+      return RotateCcw;
     default:
       return CircleDot;
   }
@@ -195,6 +203,9 @@ export default async function TrackPage({ params }: TrackPageProps) {
 
   const statusConfig = getStatusConfig(ticket.status);
   const severityConfig = getSeverityConfig(ticket.severity);
+  const resolutionEvent = ticket.ticketEvents.find(
+    (e) => e.eventType === 'resolution_sent',
+  );
 
   return (
     <div className="space-y-6">
@@ -278,22 +289,40 @@ export default async function TrackPage({ params }: TrackPageProps) {
         </CardContent>
       </Card>
 
-      {/* Resolved notice */}
-      {ticket.resolvedAt && (
+      {/* Resolution Summary */}
+      {ticket.resolvedAt || ticket.status === 'merged' ? (
         <Card className="border-success/30 bg-success/5">
           <CardContent className="pt-6">
-            <div className="flex items-center gap-3">
-              <CheckCircle2 className="h-5 w-5 text-success" />
-              <div>
-                <p className="font-medium">This issue has been resolved</p>
-                <p className="text-sm text-muted-foreground">
-                  Resolved {formatDistanceToNow(new Date(ticket.resolvedAt), { addSuffix: true })}
-                </p>
+            <div className="flex items-start gap-3">
+              <CheckCircle2 className="mt-0.5 h-5 w-5 shrink-0 text-success" />
+              <div className="space-y-3">
+                <div>
+                  <p className="font-medium">This issue has been resolved</p>
+                  {ticket.resolvedAt && (
+                    <p className="text-sm text-muted-foreground">
+                      Resolved {formatDistanceToNow(new Date(ticket.resolvedAt), { addSuffix: true })}
+                    </p>
+                  )}
+                </div>
+                {resolutionEvent && (
+                  <>
+                    {resolutionEvent.data.summary && (
+                      <p className="text-sm">{String(resolutionEvent.data.summary)}</p>
+                    )}
+                    {Array.isArray(resolutionEvent.data.changes) && resolutionEvent.data.changes.length > 0 && (
+                      <ul className="list-disc pl-5 text-sm text-muted-foreground space-y-1">
+                        {(resolutionEvent.data.changes as string[]).map((change, i) => (
+                          <li key={i}>{change}</li>
+                        ))}
+                      </ul>
+                    )}
+                  </>
+                )}
               </div>
             </div>
           </CardContent>
         </Card>
-      )}
+      ) : null}
 
       {/* Footer help section */}
       <Card>


### PR DESCRIPTION
## Summary
- **AI-generated resolution summaries** sent to clients when PRs are merged, explaining what was fixed in plain language
- **Token-based ticket reopen** mechanism — clients can click "Still having issues?" in the email to reopen their ticket
- **TicketMessage model** added for storing conversation history (system messages, client responses)
- **Enhanced tracking page** shows resolution details and changes list on the public tracking page

## New Files
- `ResolutionSummaryService` — generates client-friendly AI summaries via OpenAI
- `AutoResponseService` — orchestrates merge → summary → email → timeline flow
- `TicketReopenController` — public `POST /api/sdk/tickets/:id/reopen?token=` endpoint (rate-limited, no auth)
- `TicketMessage` Prisma model + migration
- 18 unit tests across 3 test files

## Modified Files
- `AutoMergeService` — triggers auto-response after PR merge
- `NotificationProcessor` — new `ticket_resolved` email template with reopen button
- `TicketTimelineService` — `resolution_sent` + `ticket_reopened` as notifiable events
- `TicketTrackingController` — new events added to customer-facing list
- Tracking page (`apps/web`) — shows resolution summary + changes

## Test plan
- [ ] Verify `pnpm build` passes (0 errors) ✅
- [ ] Verify unit tests pass for new services and controller
- [ ] Test auto-response flow: merge a PR → verify email dispatched with summary
- [ ] Test reopen endpoint: `POST /api/sdk/tickets/:id/reopen?token=xxx`
- [ ] Verify tracking page shows `resolution_sent` event with summary
- [ ] Verify invalid/expired tokens are rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)