### PR TITLE
feat(api,dashboard,worker): usage & billing dashboard (US-9.2)

### DIFF
--- a/apps/api/src/modules/license/dto/usage.dto.ts
+++ b/apps/api/src/modules/license/dto/usage.dto.ts
@@ -1,0 +1,58 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class UsageMetricDto {
+  @ApiProperty({ example: 'tickets' })
+  metric: string;
+
+  @ApiProperty({ example: 45 })
+  current: number;
+
+  @ApiProperty({ example: 500 })
+  limit: number;
+
+  @ApiProperty({ example: 9, description: 'Usage percentage (0-100)' })
+  percentage: number;
+}
+
+export class UsageAlertDto {
+  @ApiProperty({ example: 'agent_tasks' })
+  metric: string;
+
+  @ApiProperty({ example: 82 })
+  percentage: number;
+
+  @ApiProperty({ example: 'Agent tasks usage at 82%' })
+  message: string;
+}
+
+export class UsageResponseDto {
+  @ApiProperty({ example: 'pro' })
+  plan: string;
+
+  @ApiProperty({ type: [UsageMetricDto] })
+  metrics: UsageMetricDto[];
+
+  @ApiProperty({ example: '2026-12-31T00:00:00.000Z', nullable: true })
+  expiresAt: string | null;
+
+  @ApiProperty({ type: [UsageAlertDto] })
+  alerts: UsageAlertDto[];
+}
+
+export class UsageSeriesDto {
+  @ApiProperty({ example: 'tickets' })
+  metric: string;
+
+  @ApiProperty({ example: [30, 45, 38, 52, 41, 45] })
+  data: number[];
+}
+
+export class UsageHistoryResponseDto {
+  @ApiProperty({
+    example: ['2025-09', '2025-10', '2025-11', '2025-12', '2026-01', '2026-02'],
+  })
+  months: string[];
+
+  @ApiProperty({ type: [UsageSeriesDto] })
+  series: UsageSeriesDto[];
+}

--- a/apps/api/src/modules/license/license.controller.ts
+++ b/apps/api/src/modules/license/license.controller.ts
@@ -5,6 +5,10 @@ import { CurrentUser } from '../../common/decorators/current-user.decorator';
 import { Public } from '../../common/decorators/public.decorator';
 import { UserPayload } from '../../common/interfaces/user-payload.interface';
 import { LicenseService } from './license.service';
+import {
+  UsageResponseDto,
+  UsageHistoryResponseDto,
+} from './dto/usage.dto';
 
 @ApiTags('System')
 @Controller('system')
@@ -51,5 +55,85 @@ export class LicenseController {
   async dismissChangelog(@CurrentUser() user: UserPayload) {
     await this.licenseService.dismissChangelogForUser(user.userId);
     return { success: true };
+  }
+
+  @Get('usage')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'Get current usage metrics for authenticated tenant',
+  })
+  async getUsage(
+    @CurrentUser() user: UserPayload,
+  ): Promise<UsageResponseDto> {
+    const plan = this.licenseService.getPlan();
+    const limits = this.licenseService.getPlanLimits();
+    const currentUsage = await this.licenseService.getCurrentUsage(
+      user.tenantId,
+    );
+    const alerts = await this.licenseService.getUsageAlerts(user.tenantId);
+    const license = this.licenseService.getLicense();
+
+    const metrics = [
+      {
+        metric: 'tickets',
+        current: currentUsage.tickets,
+        limit: limits.maxTicketsPerMonth,
+        percentage:
+          limits.maxTicketsPerMonth > 0
+            ? Math.round(
+                (currentUsage.tickets / limits.maxTicketsPerMonth) * 100,
+              )
+            : 0,
+      },
+      {
+        metric: 'agent_tasks',
+        current: currentUsage.agent_tasks,
+        limit: limits.maxAgentTasksPerMonth,
+        percentage:
+          limits.maxAgentTasksPerMonth > 0
+            ? Math.round(
+                (currentUsage.agent_tasks / limits.maxAgentTasksPerMonth) * 100,
+              )
+            : 0,
+      },
+      {
+        metric: 'users',
+        current: currentUsage.users,
+        limit: limits.maxUsers,
+        percentage:
+          limits.maxUsers > 0
+            ? Math.round((currentUsage.users / limits.maxUsers) * 100)
+            : 0,
+      },
+      {
+        metric: 'repositories',
+        current: currentUsage.repositories,
+        limit: limits.maxRepos,
+        percentage:
+          limits.maxRepos > 0
+            ? Math.round((currentUsage.repositories / limits.maxRepos) * 100)
+            : 0,
+      },
+    ];
+
+    return {
+      plan,
+      metrics,
+      expiresAt: license?.expiresAt || null,
+      alerts,
+    };
+  }
+
+  @Get('usage/history')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'Get monthly usage history for last 6 months',
+  })
+  async getUsageHistory(
+    @CurrentUser() user: UserPayload,
+  ): Promise<UsageHistoryResponseDto> {
+    return this.licenseService.getUsageHistory(user.tenantId, 6);
   }
 }

--- a/apps/api/src/modules/license/license.service.ts
+++ b/apps/api/src/modules/license/license.service.ts
@@ -349,4 +349,235 @@ export class LicenseService implements OnModuleInit {
       },
     });
   }
+
+  async getCurrentUsage(tenantId: string): Promise<{
+    tickets: number;
+    agent_tasks: number;
+    users: number;
+    repositories: number;
+  }> {
+    const currentMonth = this.getCurrentMonth();
+    const startOfMonth = new Date(
+      parseInt(currentMonth.split('-')[0]),
+      parseInt(currentMonth.split('-')[1]) - 1,
+      1,
+    );
+
+    // Get ticket count for current month
+    const ticketsCount = await this.prisma.ticket.count({
+      where: {
+        tenantId,
+        createdAt: {
+          gte: startOfMonth,
+        },
+      },
+    });
+
+    // Get agent tasks count for current month
+    const agentTasksCount = await this.prisma.agentTask.count({
+      where: {
+        tenantId,
+        startedAt: {
+          gte: startOfMonth,
+        },
+      },
+    });
+
+    // Get active users count (total users, not monthly)
+    const usersCount = await this.prisma.user.count({
+      where: {
+        tenantId,
+      },
+    });
+
+    // Get connected repositories count
+    const reposCount = await this.prisma.$queryRaw<Array<{ count: bigint }>>`
+      SELECT COUNT(DISTINCT jsonb_array_elements(repos)->>'id') as count
+      FROM github_connections
+      WHERE tenant_id = ${tenantId}::uuid
+    `;
+
+    const repositoriesCount =
+      reposCount.length > 0 ? Number(reposCount[0].count) : 0;
+
+    return {
+      tickets: ticketsCount,
+      agent_tasks: agentTasksCount,
+      users: usersCount,
+      repositories: repositoriesCount,
+    };
+  }
+
+  async getUsageAlerts(
+    tenantId: string,
+  ): Promise<
+    Array<{ metric: string; percentage: number; message: string }>
+  > {
+    const currentUsage = await this.getCurrentUsage(tenantId);
+    const limits = this.getPlanLimits();
+    const alerts: Array<{ metric: string; percentage: number; message: string }> =
+      [];
+
+    const metricChecks = [
+      {
+        key: 'tickets' as const,
+        limit: limits.maxTicketsPerMonth,
+        label: 'Tickets',
+      },
+      {
+        key: 'agent_tasks' as const,
+        limit: limits.maxAgentTasksPerMonth,
+        label: 'Agent tasks',
+      },
+      { key: 'users' as const, limit: limits.maxUsers, label: 'Users' },
+      {
+        key: 'repositories' as const,
+        limit: limits.maxRepos,
+        label: 'Repositories',
+      },
+    ];
+
+    for (const check of metricChecks) {
+      const current = currentUsage[check.key];
+      if (check.limit > 0) {
+        const percentage = Math.round((current / check.limit) * 100);
+        if (percentage >= 80) {
+          alerts.push({
+            metric: check.key,
+            percentage,
+            message: `${check.label} usage at ${percentage}%`,
+          });
+        }
+      }
+    }
+
+    return alerts;
+  }
+
+  async getUsageHistory(
+    tenantId: string,
+    months = 6,
+  ): Promise<{
+    months: string[];
+    series: Array<{ metric: string; data: number[] }>;
+  }> {
+    const now = new Date();
+    const monthList: string[] = [];
+
+    // Generate list of last N months
+    for (let i = months - 1; i >= 0; i--) {
+      const date = new Date(now.getFullYear(), now.getMonth() - i, 1);
+      const year = date.getFullYear();
+      const month = String(date.getMonth() + 1).padStart(2, '0');
+      monthList.push(`${year}-${month}`);
+    }
+
+    // Fetch usage data from LicenseUsage table
+    const usageRecords = await this.prisma.licenseUsage.findMany({
+      where: {
+        tenantId,
+        month: {
+          in: monthList,
+        },
+      },
+      orderBy: {
+        month: 'asc',
+      },
+    });
+
+    // Group by metric
+    const metricMap = new Map<string, Map<string, number>>();
+
+    for (const record of usageRecords) {
+      if (!metricMap.has(record.metric)) {
+        metricMap.set(record.metric, new Map());
+      }
+      metricMap.get(record.metric)!.set(record.month, record.count);
+    }
+
+    // Build series data
+    const series: Array<{ metric: string; data: number[] }> = [];
+    const metricsToTrack = ['tickets', 'agent_tasks', 'users', 'repositories'];
+
+    for (const metric of metricsToTrack) {
+      const dataMap = metricMap.get(metric);
+      const data = monthList.map((month) => dataMap?.get(month) || 0);
+      series.push({ metric, data });
+    }
+
+    return {
+      months: monthList,
+      series,
+    };
+  }
+
+  async resetMonthlyCounters(): Promise<void> {
+    this.logger.log('Starting monthly usage snapshot...');
+
+    try {
+      // Get all tenants
+      const tenants = await this.prisma.tenant.findMany({
+        select: { id: true },
+      });
+
+      const currentMonth = this.getCurrentMonth();
+
+      for (const tenant of tenants) {
+        const usage = await this.getCurrentUsage(tenant.id);
+
+        // Snapshot each metric
+        const metrics = [
+          { name: 'tickets', value: usage.tickets },
+          { name: 'agent_tasks', value: usage.agent_tasks },
+          { name: 'users', value: usage.users },
+          { name: 'repositories', value: usage.repositories },
+        ];
+
+        for (const metric of metrics) {
+          await this.prisma.licenseUsage.upsert({
+            where: {
+              tenantId_month_metric: {
+                tenantId: tenant.id,
+                month: currentMonth,
+                metric: metric.name,
+              },
+            },
+            create: {
+              tenantId: tenant.id,
+              month: currentMonth,
+              metric: metric.name,
+              count: metric.value,
+            },
+            update: {
+              count: metric.value,
+            },
+          });
+        }
+      }
+
+      // Clean up old usage data (older than 12 months)
+      const now = new Date();
+      const twelveMonthsAgo = new Date(
+        now.getFullYear(),
+        now.getMonth() - 12,
+        1,
+      );
+      const year = twelveMonthsAgo.getFullYear();
+      const month = String(twelveMonthsAgo.getMonth() + 1).padStart(2, '0');
+      const cutoffMonth = `${year}-${month}`;
+
+      await this.prisma.licenseUsage.deleteMany({
+        where: {
+          month: {
+            lt: cutoffMonth,
+          },
+        },
+      });
+
+      this.logger.log('Monthly usage snapshot completed successfully');
+    } catch (error) {
+      this.logger.error(`Failed to snapshot monthly usage: ${error.message}`);
+      throw error;
+    }
+  }
 }

--- a/apps/dashboard/app/dashboard/settings/page.tsx
+++ b/apps/dashboard/app/dashboard/settings/page.tsx
@@ -141,6 +141,8 @@ export default function SettingsPage() {
   ] as const;
 
   const settingsPages = [
+    { href: '/dashboard/settings/plan', label: '💳 Plan & Usage' },
+    { href: '/dashboard/settings/license', label: '🔑 License' },
     { href: '/dashboard/settings/ai', label: '🤖 AI Configuration' },
     { href: '/dashboard/settings/github', label: '🐙 GitHub' },
     { href: '/dashboard/settings/status', label: '📊 Statut Systeme' },

--- a/apps/dashboard/app/dashboard/settings/plan/page.tsx
+++ b/apps/dashboard/app/dashboard/settings/plan/page.tsx
@@ -1,0 +1,254 @@
+/**
+ * Plan & Usage Settings Page
+ * Displays plan information, usage metrics, and billing details
+ */
+
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useRequireAuth } from '@/lib/auth';
+import { DashboardLayout } from '@/components/layout/DashboardLayout';
+import { PageLoader, Card, Badge, Button } from '@/components/ui';
+import { getCurrentUsage, getUsageHistory } from '@/lib/api/usage';
+import { UsageBar } from '@/components/usage/UsageBar';
+import { UsageHistoryChart } from '@/components/usage/UsageHistoryChart';
+import type { UsageResponse, UsageHistoryResponse } from '@/lib/types/usage';
+
+export default function PlanUsagePage() {
+  const { isLoading: authLoading } = useRequireAuth();
+
+  const [usage, setUsage] = useState<UsageResponse | null>(null);
+  const [history, setHistory] = useState<UsageHistoryResponse | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!authLoading) {
+      fetchUsageData();
+    }
+  }, [authLoading]);
+
+  const fetchUsageData = async () => {
+    try {
+      setIsLoading(true);
+      setError(null);
+      const [usageData, historyData] = await Promise.all([
+        getCurrentUsage(),
+        getUsageHistory(),
+      ]);
+      setUsage(usageData);
+      setHistory(historyData);
+    } catch (err: any) {
+      setError(err.message || 'Failed to load usage data');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const getPlanBadgeVariant = (plan: string): 'default' | 'success' | 'warning' => {
+    if (plan === 'enterprise') return 'success';
+    if (plan === 'pro') return 'warning';
+    return 'default';
+  };
+
+  const getMetricLabel = (metric: string): string => {
+    const labels: Record<string, string> = {
+      tickets: 'Tickets This Month',
+      agent_tasks: 'Agent AI Tasks',
+      users: 'Active Users',
+      repos: 'Connected Repositories',
+    };
+    return labels[metric] || metric;
+  };
+
+  if (authLoading || isLoading) {
+    return <PageLoader />;
+  }
+
+  if (error && !usage) {
+    return (
+      <DashboardLayout>
+        <div className="max-w-5xl mx-auto">
+          <div className="mb-8">
+            <div className="flex items-center space-x-3 mb-2">
+              <a
+                href="/dashboard/settings"
+                className="text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200"
+              >
+                Settings
+              </a>
+              <span className="text-gray-300 dark:text-gray-600">/</span>
+              <span className="text-sm text-gray-900 dark:text-white font-medium">
+                Plan & Usage
+              </span>
+            </div>
+            <h1 className="text-3xl font-bold text-gray-900 dark:text-white">
+              Plan & Usage
+            </h1>
+          </div>
+
+          <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-6">
+            <h3 className="text-lg font-medium text-red-800 dark:text-red-300 mb-2">
+              Error Loading Usage Data
+            </h3>
+            <p className="text-sm text-red-700 dark:text-red-400">{error}</p>
+            <Button onClick={fetchUsageData} className="mt-4">
+              Retry
+            </Button>
+          </div>
+        </div>
+      </DashboardLayout>
+    );
+  }
+
+  return (
+    <DashboardLayout>
+      <div className="max-w-5xl mx-auto">
+        {/* Header */}
+        <div className="mb-8">
+          <div className="flex items-center space-x-3 mb-2">
+            <a
+              href="/dashboard/settings"
+              className="text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200"
+            >
+              Settings
+            </a>
+            <span className="text-gray-300 dark:text-gray-600">/</span>
+            <span className="text-sm text-gray-900 dark:text-white font-medium">
+              Plan & Usage
+            </span>
+          </div>
+          <h1 className="text-3xl font-bold text-gray-900 dark:text-white">
+            Plan & Usage
+          </h1>
+          <p className="text-gray-600 dark:text-gray-400 mt-1">
+            Monitor your subscription plan and resource usage
+          </p>
+        </div>
+
+        {usage && (
+          <>
+            {/* Plan Overview Card */}
+            <Card className="mb-6">
+              <div className="flex items-start justify-between">
+                <div>
+                  <div className="flex items-center space-x-3 mb-2">
+                    <h2 className="text-2xl font-semibold text-gray-900 dark:text-white capitalize">
+                      {usage.plan} Plan
+                    </h2>
+                    <Badge variant={getPlanBadgeVariant(usage.plan)}>
+                      {usage.plan.toUpperCase()}
+                    </Badge>
+                  </div>
+                  {usage.expiresAt && (
+                    <p className="text-sm text-gray-600 dark:text-gray-400">
+                      License expires on{' '}
+                      {new Date(usage.expiresAt).toLocaleDateString('en-US', {
+                        year: 'numeric',
+                        month: 'long',
+                        day: 'numeric',
+                      })}
+                    </p>
+                  )}
+                </div>
+                <div>
+                  <a href="/dashboard/settings/license">
+                    <Button>Manage License</Button>
+                  </a>
+                </div>
+              </div>
+            </Card>
+
+            {/* Alerts Section */}
+            {usage.alerts && usage.alerts.length > 0 && (
+              <div className="mb-6 space-y-3">
+                {usage.alerts.map((alert, idx) => (
+                  <div
+                    key={idx}
+                    className="bg-orange-50 dark:bg-orange-900/20 border border-orange-200 dark:border-orange-800 rounded-lg p-4"
+                  >
+                    <div className="flex items-start">
+                      <svg
+                        className="w-5 h-5 text-orange-500 mr-3 mt-0.5"
+                        fill="none"
+                        stroke="currentColor"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          strokeWidth={2}
+                          d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+                        />
+                      </svg>
+                      <div>
+                        <h3 className="text-sm font-medium text-orange-800 dark:text-orange-300">
+                          Usage Warning
+                        </h3>
+                        <p className="text-sm text-orange-700 dark:text-orange-400 mt-1">
+                          {alert.message}
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+
+            {/* Usage Metrics Section */}
+            <div className="mb-6">
+              <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-4">
+                Current Usage
+              </h2>
+              <Card>
+                <div className="space-y-6">
+                  {usage.metrics.map((metric, idx) => (
+                    <UsageBar
+                      key={idx}
+                      label={getMetricLabel(metric.metric)}
+                      current={metric.current}
+                      limit={metric.limit}
+                      percentage={metric.percentage}
+                    />
+                  ))}
+                </div>
+              </Card>
+            </div>
+
+            {/* Usage History Chart */}
+            {history && history.data.length > 0 && (
+              <div className="mb-6">
+                <Card>
+                  <UsageHistoryChart data={history.data} />
+                </Card>
+              </div>
+            )}
+
+            {/* Plan Features Info */}
+            <Card>
+              <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-4">
+                Plan Features
+              </h2>
+              <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">
+                For detailed plan comparison and feature information, visit the{' '}
+                <a
+                  href="/dashboard/settings/license"
+                  className="text-blue-600 dark:text-blue-400 hover:underline"
+                >
+                  License Settings
+                </a>{' '}
+                page.
+              </p>
+              <div className="border-t border-gray-200 dark:border-gray-700 pt-4">
+                <p className="text-xs text-gray-500 dark:text-gray-400">
+                  Need to upgrade? Contact support or update your license key in the License
+                  Settings.
+                </p>
+              </div>
+            </Card>
+          </>
+        )}
+      </div>
+    </DashboardLayout>
+  );
+}

--- a/apps/dashboard/components/usage/UsageBar.tsx
+++ b/apps/dashboard/components/usage/UsageBar.tsx
@@ -1,0 +1,46 @@
+/**
+ * UsageBar Component
+ * Displays a single usage metric with a progress bar
+ */
+
+'use client';
+
+interface UsageBarProps {
+  label: string;
+  current: number;
+  limit: number | null;
+  percentage: number;
+}
+
+export function UsageBar({ label, current, limit, percentage }: UsageBarProps) {
+  const getColor = () => {
+    if (percentage >= 80) return 'bg-red-500';
+    if (percentage >= 60) return 'bg-orange-500';
+    return 'bg-green-500';
+  };
+
+  const formatLimit = (limit: number | null): string => {
+    return limit === null ? 'Unlimited' : limit.toLocaleString();
+  };
+
+  return (
+    <div>
+      <div className="flex justify-between items-center mb-2">
+        <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
+          {label}
+        </span>
+        <span className="text-sm text-gray-600 dark:text-gray-400">
+          {current.toLocaleString()} / {formatLimit(limit)}
+        </span>
+      </div>
+      <div className="h-2 rounded-full bg-gray-200 dark:bg-gray-700 overflow-hidden">
+        <div
+          className={`h-2 rounded-full transition-all duration-500 ${getColor()}`}
+          style={{
+            width: `${Math.min(percentage, 100)}%`,
+          }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/dashboard/components/usage/UsageHistoryChart.tsx
+++ b/apps/dashboard/components/usage/UsageHistoryChart.tsx
@@ -1,0 +1,198 @@
+/**
+ * UsageHistoryChart Component
+ * Line chart showing usage history over time
+ */
+
+'use client';
+
+import type { MonthlyUsageData } from '@/lib/types/usage';
+
+interface UsageHistoryChartProps {
+  data: MonthlyUsageData[];
+}
+
+export function UsageHistoryChart({ data }: UsageHistoryChartProps) {
+  if (data.length === 0) {
+    return (
+      <div className="text-center py-8 text-gray-500 dark:text-gray-400">
+        No usage history available
+      </div>
+    );
+  }
+
+  // Find max value for scaling
+  const maxTickets = Math.max(...data.map((d) => d.tickets), 1);
+  const maxAgentTasks = Math.max(...data.map((d) => d.agent_tasks), 1);
+  const maxValue = Math.max(maxTickets, maxAgentTasks);
+
+  // Calculate chart dimensions
+  const chartHeight = 200;
+  const chartPadding = { top: 20, right: 20, bottom: 40, left: 50 };
+  const chartWidth = 600;
+  const dataWidth = chartWidth - chartPadding.left - chartPadding.right;
+  const dataHeight = chartHeight - chartPadding.top - chartPadding.bottom;
+
+  // Calculate positions
+  const xStep = dataWidth / (data.length - 1 || 1);
+
+  const getY = (value: number) => {
+    return chartPadding.top + dataHeight - (value / maxValue) * dataHeight;
+  };
+
+  // Create path for tickets
+  const ticketsPath = data
+    .map((d, i) => {
+      const x = chartPadding.left + i * xStep;
+      const y = getY(d.tickets);
+      return i === 0 ? `M ${x} ${y}` : `L ${x} ${y}`;
+    })
+    .join(' ');
+
+  // Create path for agent tasks
+  const agentTasksPath = data
+    .map((d, i) => {
+      const x = chartPadding.left + i * xStep;
+      const y = getY(d.agent_tasks);
+      return i === 0 ? `M ${x} ${y}` : `L ${x} ${y}`;
+    })
+    .join(' ');
+
+  // Create area path for tickets (filled)
+  const ticketsAreaPath =
+    ticketsPath +
+    ` L ${chartPadding.left + (data.length - 1) * xStep} ${
+      chartPadding.top + dataHeight
+    } L ${chartPadding.left} ${chartPadding.top + dataHeight} Z`;
+
+  return (
+    <div>
+      <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">
+        Usage History (Last 6 Months)
+      </h3>
+
+      <div className="overflow-x-auto">
+        <svg
+          width={chartWidth}
+          height={chartHeight}
+          className="mx-auto"
+          viewBox={`0 0 ${chartWidth} ${chartHeight}`}
+        >
+          {/* Grid lines */}
+          {[0, 0.25, 0.5, 0.75, 1].map((ratio) => {
+            const y = chartPadding.top + dataHeight * (1 - ratio);
+            return (
+              <g key={ratio}>
+                <line
+                  x1={chartPadding.left}
+                  y1={y}
+                  x2={chartWidth - chartPadding.right}
+                  y2={y}
+                  stroke="currentColor"
+                  strokeDasharray="2,2"
+                  className="text-gray-300 dark:text-gray-600"
+                  strokeWidth="0.5"
+                />
+                <text
+                  x={chartPadding.left - 10}
+                  y={y + 4}
+                  textAnchor="end"
+                  className="text-xs fill-gray-500 dark:fill-gray-400"
+                >
+                  {Math.round(maxValue * ratio)}
+                </text>
+              </g>
+            );
+          })}
+
+          {/* Area fill for tickets */}
+          <path
+            d={ticketsAreaPath}
+            fill="#3b82f6"
+            fillOpacity="0.1"
+          />
+
+          {/* Line for tickets */}
+          <path
+            d={ticketsPath}
+            fill="none"
+            stroke="#3b82f6"
+            strokeWidth="2"
+          />
+
+          {/* Line for agent tasks */}
+          <path
+            d={agentTasksPath}
+            fill="none"
+            stroke="#8b5cf6"
+            strokeWidth="2"
+          />
+
+          {/* Data points for tickets */}
+          {data.map((d, i) => {
+            const x = chartPadding.left + i * xStep;
+            const y = getY(d.tickets);
+            return (
+              <circle
+                key={`tickets-${i}`}
+                cx={x}
+                cy={y}
+                r="4"
+                fill="#3b82f6"
+                className="hover:r-6 transition-all cursor-pointer"
+              >
+                <title>{`${d.month}: ${d.tickets} tickets`}</title>
+              </circle>
+            );
+          })}
+
+          {/* Data points for agent tasks */}
+          {data.map((d, i) => {
+            const x = chartPadding.left + i * xStep;
+            const y = getY(d.agent_tasks);
+            return (
+              <circle
+                key={`tasks-${i}`}
+                cx={x}
+                cy={y}
+                r="4"
+                fill="#8b5cf6"
+                className="hover:r-6 transition-all cursor-pointer"
+              >
+                <title>{`${d.month}: ${d.agent_tasks} agent tasks`}</title>
+              </circle>
+            );
+          })}
+
+          {/* X-axis labels */}
+          {data.map((d, i) => {
+            const x = chartPadding.left + i * xStep;
+            const y = chartHeight - chartPadding.bottom + 20;
+            return (
+              <text
+                key={`label-${i}`}
+                x={x}
+                y={y}
+                textAnchor="middle"
+                className="text-xs fill-gray-500 dark:fill-gray-400"
+              >
+                {d.month}
+              </text>
+            );
+          })}
+        </svg>
+      </div>
+
+      {/* Legend */}
+      <div className="flex justify-center gap-6 mt-4">
+        <div className="flex items-center gap-2">
+          <div className="w-3 h-3 rounded-full bg-blue-500"></div>
+          <span className="text-sm text-gray-600 dark:text-gray-400">Tickets</span>
+        </div>
+        <div className="flex items-center gap-2">
+          <div className="w-3 h-3 rounded-full bg-purple-500"></div>
+          <span className="text-sm text-gray-600 dark:text-gray-400">Agent Tasks</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/dashboard/lib/api/usage.ts
+++ b/apps/dashboard/lib/api/usage.ts
@@ -1,0 +1,21 @@
+/**
+ * Usage API Client
+ * API client for usage and billing endpoints
+ */
+
+import { apiRequest } from './client';
+import type { UsageResponse, UsageHistoryResponse } from '../types/usage';
+
+/**
+ * Get current usage metrics
+ */
+export async function getCurrentUsage(): Promise<UsageResponse> {
+  return apiRequest<UsageResponse>('/api/system/usage');
+}
+
+/**
+ * Get usage history over time
+ */
+export async function getUsageHistory(): Promise<UsageHistoryResponse> {
+  return apiRequest<UsageHistoryResponse>('/api/system/usage/history');
+}

--- a/apps/dashboard/lib/types/usage.ts
+++ b/apps/dashboard/lib/types/usage.ts
@@ -1,0 +1,35 @@
+/**
+ * Usage Types
+ * Type definitions for usage and billing
+ */
+
+export interface UsageMetric {
+  metric: 'tickets' | 'agent_tasks' | 'users' | 'repos';
+  current: number;
+  limit: number | null;
+  percentage: number;
+}
+
+export interface UsageAlert {
+  metric: string;
+  percentage: number;
+  message: string;
+}
+
+export interface UsageResponse {
+  plan: 'free' | 'pro' | 'enterprise';
+  metrics: UsageMetric[];
+  expiresAt: string | null;
+  alerts: UsageAlert[];
+}
+
+export interface MonthlyUsageData {
+  month: string;
+  tickets: number;
+  agent_tasks: number;
+}
+
+export interface UsageHistoryResponse {
+  months: string[];
+  data: MonthlyUsageData[];
+}

--- a/apps/worker/src/main.ts
+++ b/apps/worker/src/main.ts
@@ -60,6 +60,7 @@ async function bootstrap() {
   logger.log('  - AgentWorker (agent-orchestration queue, 5 retries)');
   logger.log('  - IntegrationSyncWorker (integration-sync queue, 4 retries)');
   logger.log('  - BackupWorker (backup queue, 3 retries)');
+  logger.log('  - UsageSnapshotProcessor (usage-snapshot queue, monthly cron)');
   logger.log('  - DeadLetterWorker (dead-letter queue)');
   logger.log('Retry Strategy: Exponential backoff (1min, 5min, 15min, 1hr)');
   logger.log(`Concurrency: ${process.env.WORKER_CONCURRENCY || 10} jobs`);

--- a/apps/worker/src/processors/processors.module.ts
+++ b/apps/worker/src/processors/processors.module.ts
@@ -6,6 +6,7 @@ import { IntegrationSyncWorker } from '../workers/integration-sync.worker';
 import { CodebaseIndexingWorker } from '../workers/codebase-indexing.worker';
 import { BackupWorker } from '../workers/backup.worker';
 import { DeadLetterWorker } from '../workers/dead-letter.worker';
+import { UsageSnapshotProcessor } from './usage-snapshot.processor';
 
 /**
  * Processors Module
@@ -21,6 +22,7 @@ import { DeadLetterWorker } from '../workers/dead-letter.worker';
     CodebaseIndexingWorker,
     BackupWorker,
     DeadLetterWorker,
+    UsageSnapshotProcessor,
   ],
   exports: [
     VideoAnalysisWorker,
@@ -30,6 +32,7 @@ import { DeadLetterWorker } from '../workers/dead-letter.worker';
     CodebaseIndexingWorker,
     BackupWorker,
     DeadLetterWorker,
+    UsageSnapshotProcessor,
   ],
 })
 export class ProcessorsModule {}

--- a/apps/worker/src/processors/usage-snapshot.processor.ts
+++ b/apps/worker/src/processors/usage-snapshot.processor.ts
@@ -1,0 +1,175 @@
+import { Processor, WorkerHost } from '@nestjs/bullmq';
+import { Logger } from '@nestjs/common';
+import { Job } from 'bullmq';
+import { PrismaClient } from '@prisma/client';
+
+/**
+ * UsageSnapshotProcessor
+ *
+ * Scheduled job that runs at the start of each month to:
+ * 1. Snapshot current usage metrics into LicenseUsage table
+ * 2. Clean up usage data older than 12 months
+ *
+ * This processor is triggered by a repeatable job added to the 'usage-snapshot' queue.
+ */
+@Processor('usage-snapshot')
+export class UsageSnapshotProcessor extends WorkerHost {
+  private readonly logger = new Logger(UsageSnapshotProcessor.name);
+  private readonly prisma: PrismaClient;
+
+  constructor() {
+    super();
+    this.prisma = new PrismaClient();
+  }
+
+  async process(_job: Job): Promise<void> {
+    this.logger.log('Starting monthly usage snapshot...');
+
+    try {
+      // Get all tenants
+      const tenants = await this.prisma.tenant.findMany({
+        select: { id: true },
+      });
+
+      const currentMonth = this.getCurrentMonth();
+
+      for (const tenant of tenants) {
+        const usage = await this.getCurrentUsage(tenant.id);
+
+        // Snapshot each metric
+        const metrics = [
+          { name: 'tickets', value: usage.tickets },
+          { name: 'agent_tasks', value: usage.agent_tasks },
+          { name: 'users', value: usage.users },
+          { name: 'repositories', value: usage.repositories },
+        ];
+
+        for (const metric of metrics) {
+          await this.prisma.licenseUsage.upsert({
+            where: {
+              tenantId_month_metric: {
+                tenantId: tenant.id,
+                month: currentMonth,
+                metric: metric.name,
+              },
+            },
+            create: {
+              tenantId: tenant.id,
+              month: currentMonth,
+              metric: metric.name,
+              count: metric.value,
+            },
+            update: {
+              count: metric.value,
+            },
+          });
+        }
+
+        this.logger.log(
+          `Snapshot completed for tenant ${tenant.id}: ${JSON.stringify(usage)}`,
+        );
+      }
+
+      // Clean up old usage data (older than 12 months)
+      const now = new Date();
+      const twelveMonthsAgo = new Date(
+        now.getFullYear(),
+        now.getMonth() - 12,
+        1,
+      );
+      const year = twelveMonthsAgo.getFullYear();
+      const month = String(twelveMonthsAgo.getMonth() + 1).padStart(2, '0');
+      const cutoffMonth = `${year}-${month}`;
+
+      const deleted = await this.prisma.licenseUsage.deleteMany({
+        where: {
+          month: {
+            lt: cutoffMonth,
+          },
+        },
+      });
+
+      this.logger.log(
+        `Cleaned up ${deleted.count} old usage records before ${cutoffMonth}`,
+      );
+      this.logger.log('Monthly usage snapshot completed successfully');
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : 'Unknown error';
+      this.logger.error(`Failed to snapshot monthly usage: ${errorMessage}`);
+      throw error;
+    }
+  }
+
+  private async getCurrentUsage(tenantId: string): Promise<{
+    tickets: number;
+    agent_tasks: number;
+    users: number;
+    repositories: number;
+  }> {
+    const currentMonth = this.getCurrentMonth();
+    const [yearStr, monthStr] = currentMonth.split('-');
+    const startOfMonth = new Date(
+      parseInt(yearStr || '2026'),
+      parseInt(monthStr || '1') - 1,
+      1,
+    );
+
+    // Get ticket count for current month
+    const ticketsCount = await this.prisma.ticket.count({
+      where: {
+        tenantId,
+        createdAt: {
+          gte: startOfMonth,
+        },
+      },
+    });
+
+    // Get agent tasks count for current month
+    const agentTasksCount = await this.prisma.agentTask.count({
+      where: {
+        tenantId,
+        startedAt: {
+          gte: startOfMonth,
+        },
+      },
+    });
+
+    // Get active users count (total users, not monthly)
+    const usersCount = await this.prisma.user.count({
+      where: {
+        tenantId,
+      },
+    });
+
+    // Get connected repositories count
+    const reposCount = await this.prisma.$queryRaw<Array<{ count: bigint }>>`
+      SELECT COUNT(DISTINCT jsonb_array_elements(repos)->>'id') as count
+      FROM github_connections
+      WHERE tenant_id = ${tenantId}::uuid
+    `;
+
+    const repositoriesCount =
+      reposCount.length > 0 && reposCount[0]
+        ? Number(reposCount[0].count)
+        : 0;
+
+    return {
+      tickets: ticketsCount,
+      agent_tasks: agentTasksCount,
+      users: usersCount,
+      repositories: repositoriesCount,
+    };
+  }
+
+  private getCurrentMonth(): string {
+    const now = new Date();
+    const year = now.getFullYear();
+    const month = String(now.getMonth() + 1).padStart(2, '0');
+    return `${year}-${month}`;
+  }
+
+  async onModuleDestroy() {
+    await this.prisma.$disconnect();
+  }
+}

--- a/apps/worker/src/queues/queues.module.ts
+++ b/apps/worker/src/queues/queues.module.ts
@@ -10,6 +10,7 @@ export const QUEUE_NAMES = {
   INTEGRATION_SYNC: 'integration-sync',
   CODEBASE_INDEXING: 'codebase-indexing',
   BACKUP: 'backup',
+  USAGE_SNAPSHOT: 'usage-snapshot',
 } as const;
 
 export type QueueName = (typeof QUEUE_NAMES)[keyof typeof QUEUE_NAMES];
@@ -136,6 +137,20 @@ export type QueueName = (typeof QUEUE_NAMES)[keyof typeof QUEUE_NAMES];
         },
         removeOnComplete: 100,
         removeOnFail: 500,
+      },
+    }),
+
+    // Usage Snapshot Queue (Monthly cron)
+    BullModule.registerQueue({
+      name: QUEUE_NAMES.USAGE_SNAPSHOT,
+      defaultJobOptions: {
+        attempts: 3,
+        backoff: {
+          type: 'exponential',
+          delay: 10000,
+        },
+        removeOnComplete: 10,
+        removeOnFail: 50,
       },
     }),
 

--- a/apps/worker/src/services/services.module.ts
+++ b/apps/worker/src/services/services.module.ts
@@ -14,6 +14,9 @@ import {
   PullRequestService,
 } from './index';
 import { JobMonitoringService } from './job-monitoring.service';
+import { UsageSnapshotSchedulerService } from './usage-snapshot-scheduler.service';
+import { BullModule } from '@nestjs/bullmq';
+import { QUEUE_NAMES } from '../queues/queues.module';
 
 /**
  * Services Module
@@ -22,6 +25,7 @@ import { JobMonitoringService } from './job-monitoring.service';
  */
 @Global()
 @Module({
+  imports: [BullModule.registerQueue({ name: QUEUE_NAMES.USAGE_SNAPSHOT })],
   providers: [
     PrismaService,
     FFmpegService,
@@ -36,6 +40,7 @@ import { JobMonitoringService } from './job-monitoring.service';
     JobMonitoringService,
     GitAutomationService,
     PullRequestService,
+    UsageSnapshotSchedulerService,
   ],
   exports: [
     PrismaService,
@@ -51,6 +56,7 @@ import { JobMonitoringService } from './job-monitoring.service';
     JobMonitoringService,
     GitAutomationService,
     PullRequestService,
+    UsageSnapshotSchedulerService,
   ],
 })
 export class ServicesModule {}

--- a/apps/worker/src/services/usage-snapshot-scheduler.service.ts
+++ b/apps/worker/src/services/usage-snapshot-scheduler.service.ts
@@ -1,0 +1,46 @@
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { InjectQueue } from '@nestjs/bullmq';
+import { Queue } from 'bullmq';
+import { QUEUE_NAMES } from '../queues/queues.module';
+
+/**
+ * UsageSnapshotSchedulerService
+ *
+ * Schedules a repeatable job to snapshot usage metrics monthly.
+ * Job runs at 00:00 on the 1st of every month.
+ */
+@Injectable()
+export class UsageSnapshotSchedulerService implements OnModuleInit {
+  private readonly logger = new Logger(UsageSnapshotSchedulerService.name);
+
+  constructor(
+    @InjectQueue(QUEUE_NAMES.USAGE_SNAPSHOT)
+    private readonly usageSnapshotQueue: Queue,
+  ) {}
+
+  async onModuleInit() {
+    try {
+      // Add repeatable job: runs at 00:00 on the 1st of every month
+      await this.usageSnapshotQueue.add(
+        'monthly-snapshot',
+        {},
+        {
+          repeat: {
+            pattern: '0 0 1 * *', // Cron: At 00:00 on day-of-month 1
+          },
+          jobId: 'usage-snapshot-monthly',
+        },
+      );
+
+      this.logger.log(
+        'Usage snapshot scheduled: Runs at 00:00 on the 1st of every month',
+      );
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : 'Unknown error';
+      this.logger.error(
+        `Failed to schedule usage snapshot job: ${errorMessage}`,
+      );
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- **Usage API**: `GET /api/system/usage` (current metrics + limits) and `GET /api/system/usage/history` (6-month trend)
- **Usage alerts**: Auto-detects metrics exceeding 80% of plan limits
- **Dashboard page**: Plan & Usage at `/dashboard/settings/plan` with UsageBar + SVG chart
- **Monthly cron**: Snapshots usage into `license_usage` table on 1st of each month
- Color-coded progress bars: green (<60%), orange (60-80%), red (>80%)

## Test plan
- [ ] Verify `pnpm build` passes (all 7 packages)
- [ ] Verify `/dashboard/settings/plan` renders with usage bars
- [ ] Verify `GET /api/system/usage` returns correct metrics
- [ ] Verify `GET /api/system/usage/history` returns 6-month data
- [ ] Verify alerts appear when usage > 80%

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)