### PR TITLE
feat(api,dashboard): multi-provider AI support (US-8.2)

### DIFF
--- a/apps/api/src/ai/ai.module.ts
+++ b/apps/api/src/ai/ai.module.ts
@@ -1,8 +1,11 @@
 import { Module } from '@nestjs/common';
 import { AIService } from './ai.service';
+import { AIProviderFactory } from './providers/ai-provider.factory';
+import { PrismaModule } from '../prisma/prisma.module';
 
 @Module({
-  providers: [AIService],
-  exports: [AIService],
+  imports: [PrismaModule],
+  providers: [AIService, AIProviderFactory],
+  exports: [AIService, AIProviderFactory],
 })
 export class AIModule {}

--- a/apps/api/src/ai/ai.service.ts
+++ b/apps/api/src/ai/ai.service.ts
@@ -1,6 +1,9 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import OpenAI from 'openai';
+import { PrismaService } from '../prisma/prisma.service';
+import { AIProvider } from './providers/ai-provider.interface';
+import { AIProviderFactory } from './providers/ai-provider.factory';
+import { AIProviderConfig, DEFAULT_MODELS } from './providers/ai-provider.types';
 
 export interface VideoAnalysisResult {
   summary: string;
@@ -18,44 +21,149 @@ const EMBEDDING_MAX_CHARS = 32000; // ~8191 tokens * ~4 chars/token
 @Injectable()
 export class AIService {
   private readonly logger = new Logger(AIService.name);
-  private openai: OpenAI;
-  private readonly embeddingModel: string;
+  private provider: AIProvider | null = null;
+  private providerConfig: AIProviderConfig | null = null;
 
-  constructor(private configService: ConfigService) {
-    const apiKey = this.configService.get<string>('OPENAI_API_KEY');
-    if (!apiKey) {
-      this.logger.warn('OPENAI_API_KEY not configured - AI features disabled');
-    } else {
-      this.openai = new OpenAI({ apiKey });
+  constructor(
+    private configService: ConfigService,
+    private prisma: PrismaService,
+    private providerFactory: AIProviderFactory,
+  ) {}
+
+  /**
+   * Initialize or recreate provider based on current config
+   */
+  private async initializeProvider(tenantId?: string): Promise<void> {
+    const config = await this.getProviderConfig(tenantId);
+
+    // Only recreate if config changed
+    const configKey = JSON.stringify(config);
+    const currentKey = this.providerConfig ? JSON.stringify(this.providerConfig) : null;
+
+    if (configKey !== currentKey) {
+      this.providerConfig = config;
+      this.provider = config ? this.providerFactory.create(config) : null;
     }
-    this.embeddingModel = this.configService.get<string>(
-      'EMBEDDING_MODEL',
-      'text-embedding-3-small',
-    );
+  }
+
+  /**
+   * Get provider config from SystemConfig or env vars (fallback)
+   */
+  async getProviderConfig(tenantId?: string): Promise<AIProviderConfig | null> {
+    // Try to get per-tenant config first (if tenantId provided)
+    if (tenantId) {
+      try {
+        const aiConfig = await this.prisma.aiConfig.findUnique({
+          where: { tenantId },
+        });
+
+        if (aiConfig) {
+          return {
+            provider: aiConfig.provider as any,
+            apiKey: aiConfig.encryptedApiKey, // Auto-decrypted by Prisma middleware
+            model: aiConfig.model,
+          };
+        }
+      } catch (error) {
+        this.logger.warn(
+          `Failed to fetch tenant AI config: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        );
+      }
+    }
+
+    // Fall back to system-wide config from env vars
+    const openaiKey = this.configService.get<string>('OPENAI_API_KEY');
+    if (openaiKey) {
+      return {
+        provider: 'openai',
+        apiKey: openaiKey,
+        model: DEFAULT_MODELS.openai,
+      };
+    }
+
+    // No config available
+    return null;
+  }
+
+  /**
+   * Get the active AI provider instance
+   */
+  async getActiveProvider(tenantId?: string): Promise<AIProvider | null> {
+    await this.initializeProvider(tenantId);
+    return this.provider;
+  }
+
+  /**
+   * Update provider config (system-wide, stored in SystemConfig)
+   */
+  async updateProviderConfig(config: AIProviderConfig): Promise<void> {
+    await this.prisma.systemConfig.upsert({
+      where: { key: 'ai_config' },
+      create: {
+        key: 'ai_config',
+        value: config as any,
+      },
+      update: {
+        value: config as any,
+      },
+    });
+
+    // Invalidate cached provider
+    this.provider = null;
+    this.providerConfig = null;
+  }
+
+  /**
+   * Test connection to configured provider
+   */
+  async testConnection(tenantId?: string): Promise<{ success: boolean; message: string }> {
+    try {
+      const provider = await this.getActiveProvider(tenantId);
+
+      if (!provider) {
+        return {
+          success: false,
+          message: 'No AI provider configured',
+        };
+      }
+
+      const isValid = await provider.validateConfig();
+
+      return {
+        success: isValid,
+        message: isValid
+          ? `Successfully connected to ${provider.getProviderName()}`
+          : `Failed to connect to ${provider.getProviderName()}`,
+      };
+    } catch (error) {
+      return {
+        success: false,
+        message: error instanceof Error ? error.message : 'Unknown error',
+      };
+    }
   }
 
   /**
    * Generate embedding for a single text input.
-   * Uses OpenAI text-embedding-3-small (1536 dimensions) by default.
+   * Uses provider's embedding capability if available.
    */
-  async generateEmbedding(text: string): Promise<number[]> {
-    if (!this.openai) {
-      this.logger.warn('OpenAI not configured, cannot generate embedding');
+  async generateEmbedding(text: string, tenantId?: string): Promise<number[]> {
+    const provider = await this.getActiveProvider(tenantId);
+
+    if (!provider) {
+      this.logger.warn('No AI provider configured, cannot generate embedding');
+      return [];
+    }
+
+    if (!provider.generateEmbedding) {
+      this.logger.warn(
+        `Provider ${provider.getProviderName()} does not support embeddings`,
+      );
       return [];
     }
 
     try {
-      const truncated =
-        text.length > EMBEDDING_MAX_CHARS
-          ? text.slice(0, EMBEDDING_MAX_CHARS)
-          : text;
-
-      const response = await this.openai.embeddings.create({
-        model: this.embeddingModel,
-        input: truncated,
-      });
-
-      return response.data[0].embedding;
+      return await provider.generateEmbedding(text);
     } catch (error) {
       this.logger.error(
         `Failed to generate embedding: ${error instanceof Error ? error.message : 'Unknown error'}`,
@@ -65,46 +173,44 @@ export class AIService {
   }
 
   /**
-   * Generate embeddings for multiple texts in batches.
-   * Batches into groups of 100 and processes sequentially to respect rate limits.
+   * Generate embeddings for multiple texts.
+   * Processes sequentially if provider doesn't support batch.
    */
-  async generateEmbeddings(texts: string[]): Promise<number[][]> {
-    if (!this.openai) {
-      this.logger.warn('OpenAI not configured, cannot generate embeddings');
+  async generateEmbeddings(texts: string[], tenantId?: string): Promise<number[][]> {
+    const provider = await this.getActiveProvider(tenantId);
+
+    if (!provider || !provider.generateEmbedding) {
+      this.logger.warn('No embedding-capable AI provider configured');
       return texts.map(() => []);
     }
 
     const results: number[][] = [];
 
-    for (let i = 0; i < texts.length; i += EMBEDDING_BATCH_SIZE) {
-      const batch = texts.slice(i, i + EMBEDDING_BATCH_SIZE).map((t) =>
-        t.length > EMBEDDING_MAX_CHARS ? t.slice(0, EMBEDDING_MAX_CHARS) : t,
-      );
-
+    // Process sequentially (providers may have their own batching)
+    for (const text of texts) {
       try {
-        const response = await this.openai.embeddings.create({
-          model: this.embeddingModel,
-          input: batch,
-        });
-
-        // Sort by index to preserve order
-        const sorted = response.data.sort((a, b) => a.index - b.index);
-        results.push(...sorted.map((d) => d.embedding));
+        const embedding = await provider.generateEmbedding(text);
+        results.push(embedding);
       } catch (error) {
         this.logger.error(
-          `Failed to generate embeddings for batch starting at index ${i}: ${error instanceof Error ? error.message : 'Unknown error'}`,
+          `Failed to generate embedding: ${error instanceof Error ? error.message : 'Unknown error'}`,
         );
-        // Return empty arrays for the failed batch
-        results.push(...batch.map(() => []));
+        results.push([]);
       }
     }
 
     return results;
   }
 
-  async analyzeVideoTranscript(transcript: string, ocrText?: string): Promise<VideoAnalysisResult> {
-    if (!this.openai) {
-      this.logger.warn('OpenAI not configured, returning mock analysis');
+  async analyzeVideoTranscript(
+    transcript: string,
+    ocrText?: string,
+    tenantId?: string,
+  ): Promise<VideoAnalysisResult> {
+    const provider = await this.getActiveProvider(tenantId);
+
+    if (!provider) {
+      this.logger.warn('No AI provider configured, returning mock analysis');
       return this.getMockAnalysis(transcript);
     }
 
@@ -129,35 +235,23 @@ Please provide a JSON response with the following fields:
 Respond ONLY with valid JSON.
       `;
 
-      const response = await this.openai.chat.completions.create({
-        model: 'gpt-3.5-turbo',
-        messages: [
-          {
-            role: 'system',
-            content:
-              'You are a technical support AI that analyzes bug reports and technical issues. Always respond with valid JSON.',
-          },
-          {
-            role: 'user',
-            content: prompt,
-          },
-        ],
+      const schema = {
+        summary: 'string',
+        severity: 'string',
+        severityConfidence: 'number',
+        type: 'string',
+        typeConfidence: 'number',
+        keywords: 'array',
+        reproductionSteps: 'array',
+      };
+
+      const analysis = await provider.generateStructuredOutput<any>(prompt, schema, {
+        systemPrompt:
+          'You are a technical support AI that analyzes bug reports and technical issues. Always respond with valid JSON.',
         temperature: 0.3,
-        max_tokens: 1000,
+        maxTokens: 1000,
       });
 
-      const content = response.choices[0].message.content;
-      if (!content) {
-        throw new Error('Empty response from OpenAI');
-      }
-
-      // Extract JSON from response (in case it's wrapped in markdown)
-      const jsonMatch = content.match(/\{[\s\S]*\}/);
-      if (!jsonMatch) {
-        throw new Error('No JSON found in response');
-      }
-
-      const analysis = JSON.parse(jsonMatch[0]);
       return {
         summary: analysis.summary || 'Unable to generate summary',
         severity: analysis.severity || 'medium',
@@ -169,7 +263,7 @@ Respond ONLY with valid JSON.
       };
     } catch (error) {
       this.logger.error(
-        `Failed to analyze video: ${error instanceof Error ? error.message : 'Unknown error'}`
+        `Failed to analyze video: ${error instanceof Error ? error.message : 'Unknown error'}`,
       );
       // Return mock analysis on error for MVP
       return this.getMockAnalysis(transcript);
@@ -182,9 +276,12 @@ Respond ONLY with valid JSON.
   async processUserDescription(
     description: string,
     userContext?: Record<string, any>,
+    tenantId?: string,
   ): Promise<VideoAnalysisResult & { enrichedDescription: string }> {
-    if (!this.openai) {
-      this.logger.warn('OpenAI not configured, returning basic processing');
+    const provider = await this.getActiveProvider(tenantId);
+
+    if (!provider) {
+      this.logger.warn('No AI provider configured, returning basic processing');
       const mock = this.getMockAnalysis(description);
       return {
         ...mock,
@@ -217,34 +314,24 @@ Please provide a JSON response with the following fields:
 Respond ONLY with valid JSON.
       `;
 
-      const response = await this.openai.chat.completions.create({
-        model: 'gpt-3.5-turbo',
-        messages: [
-          {
-            role: 'system',
-            content:
-              'You are a technical support AI that processes and enriches bug reports. Always respond with valid JSON.',
-          },
-          {
-            role: 'user',
-            content: prompt,
-          },
-        ],
+      const schema = {
+        enrichedDescription: 'string',
+        summary: 'string',
+        severity: 'string',
+        severityConfidence: 'number',
+        type: 'string',
+        typeConfidence: 'number',
+        keywords: 'array',
+        reproductionSteps: 'array',
+      };
+
+      const analysis = await provider.generateStructuredOutput<any>(prompt, schema, {
+        systemPrompt:
+          'You are a technical support AI that processes and enriches bug reports. Always respond with valid JSON.',
         temperature: 0.3,
-        max_tokens: 1500,
+        maxTokens: 1500,
       });
 
-      const content = response.choices[0].message.content;
-      if (!content) {
-        throw new Error('Empty response from OpenAI');
-      }
-
-      const jsonMatch = content.match(/\{[\s\S]*\}/);
-      if (!jsonMatch) {
-        throw new Error('No JSON found in response');
-      }
-
-      const analysis = JSON.parse(jsonMatch[0]);
       return {
         enrichedDescription: analysis.enrichedDescription || description,
         summary: analysis.summary || 'Unable to generate summary',
@@ -267,65 +354,50 @@ Respond ONLY with valid JSON.
     }
   }
 
-  async classifyIssue(description: string): Promise<string> {
-    if (!this.openai) {
+  async classifyIssue(description: string, tenantId?: string): Promise<string> {
+    const provider = await this.getActiveProvider(tenantId);
+
+    if (!provider) {
       return 'other';
     }
 
     try {
-      const response = await this.openai.chat.completions.create({
-        model: 'gpt-3.5-turbo',
-        messages: [
-          {
-            role: 'system',
-            content:
-              'You are a technical support AI classifier. Classify the issue into one category only: crash, performance, ui, data-loss, feature-request, or other.',
-          },
-          {
-            role: 'user',
-            content: `Classify this issue: ${description}`,
-          },
-        ],
-        max_tokens: 20,
-        temperature: 0.1,
-      });
+      const response = await provider.generateCompletion(
+        `Classify this issue: ${description}`,
+        {
+          systemPrompt:
+            'You are a technical support AI classifier. Classify the issue into one category only: crash, performance, ui, data-loss, feature-request, or other.',
+          maxTokens: 20,
+          temperature: 0.1,
+        },
+      );
 
-      const content = response.choices[0].message.content?.toLowerCase() || 'other';
+      const content = response.toLowerCase();
       const validTypes = ['crash', 'performance', 'ui', 'data-loss', 'feature-request', 'other'];
-      return validTypes.find(t => content.includes(t)) || 'other';
+      return validTypes.find((t) => content.includes(t)) || 'other';
     } catch (error) {
       this.logger.error(`Classification failed: ${error}`);
       return 'other';
     }
   }
 
-  async generateCompletion(prompt: string): Promise<string> {
-    if (!this.openai) {
-      this.logger.warn('OpenAI not configured, returning empty response');
+  async generateCompletion(prompt: string, tenantId?: string): Promise<string> {
+    const provider = await this.getActiveProvider(tenantId);
+
+    if (!provider) {
+      this.logger.warn('No AI provider configured, returning empty response');
       return '';
     }
 
     try {
-      const response = await this.openai.chat.completions.create({
-        model: 'gpt-3.5-turbo',
-        messages: [
-          {
-            role: 'system',
-            content: 'You are a helpful technical support AI assistant.',
-          },
-          {
-            role: 'user',
-            content: prompt,
-          },
-        ],
+      return await provider.generateCompletion(prompt, {
+        systemPrompt: 'You are a helpful technical support AI assistant.',
         temperature: 0.7,
-        max_tokens: 1500,
+        maxTokens: 1500,
       });
-
-      return response.choices[0].message.content || '';
     } catch (error) {
       this.logger.error(
-        `Failed to generate completion: ${error instanceof Error ? error.message : 'Unknown error'}`
+        `Failed to generate completion: ${error instanceof Error ? error.message : 'Unknown error'}`,
       );
       return '';
     }

--- a/apps/api/src/ai/providers/ai-provider.factory.ts
+++ b/apps/api/src/ai/providers/ai-provider.factory.ts
@@ -1,0 +1,34 @@
+import { Injectable, BadRequestException } from '@nestjs/common';
+import { AIProvider } from './ai-provider.interface';
+import { AIProviderConfig } from './ai-provider.types';
+import { OpenAIProvider } from './openai.provider';
+import { AnthropicProvider } from './anthropic.provider';
+import { OllamaProvider } from './ollama.provider';
+
+@Injectable()
+export class AIProviderFactory {
+  create(config: AIProviderConfig): AIProvider {
+    switch (config.provider) {
+      case 'openai':
+        if (!config.apiKey) {
+          throw new BadRequestException('OpenAI API key is required');
+        }
+        return new OpenAIProvider(config);
+
+      case 'anthropic':
+        if (!config.apiKey) {
+          throw new BadRequestException('Anthropic API key is required');
+        }
+        return new AnthropicProvider(config);
+
+      case 'ollama':
+        // Ollama doesn't require API key
+        return new OllamaProvider(config);
+
+      default:
+        throw new BadRequestException(
+          `Unsupported AI provider: ${config.provider}`,
+        );
+    }
+  }
+}

--- a/apps/api/src/ai/providers/ai-provider.interface.ts
+++ b/apps/api/src/ai/providers/ai-provider.interface.ts
@@ -1,0 +1,16 @@
+export interface AIProvider {
+  generateCompletion(prompt: string, options?: CompletionOptions): Promise<string>;
+  generateStructuredOutput<T>(prompt: string, schema: any, options?: CompletionOptions): Promise<T>;
+  generateEmbedding?(text: string): Promise<number[]>;
+  getProviderName(): string;
+  validateConfig(): Promise<boolean>;
+}
+
+export interface CompletionOptions {
+  model?: string;
+  maxTokens?: number;
+  temperature?: number;
+  systemPrompt?: string;
+}
+
+export type AIProviderType = 'openai' | 'anthropic' | 'ollama';

--- a/apps/api/src/ai/providers/ai-provider.types.ts
+++ b/apps/api/src/ai/providers/ai-provider.types.ts
@@ -1,0 +1,21 @@
+import { AIProviderType } from './ai-provider.interface';
+
+export interface AIProviderConfig {
+  provider: AIProviderType;
+  apiKey?: string;
+  endpoint?: string;
+  model?: string;
+  organizationId?: string;
+}
+
+export const DEFAULT_MODELS: Record<AIProviderType, string> = {
+  openai: 'gpt-4o',
+  anthropic: 'claude-sonnet-4-5-20250929',
+  ollama: 'llama3.1',
+};
+
+export const PROVIDER_LABELS: Record<AIProviderType, string> = {
+  openai: 'OpenAI',
+  anthropic: 'Anthropic',
+  ollama: 'Ollama (Local)',
+};

--- a/apps/api/src/ai/providers/anthropic.provider.ts
+++ b/apps/api/src/ai/providers/anthropic.provider.ts
@@ -1,0 +1,115 @@
+import { Injectable, Logger } from '@nestjs/common';
+import Anthropic from '@anthropic-ai/sdk';
+import { AIProvider, CompletionOptions } from './ai-provider.interface';
+import { AIProviderConfig } from './ai-provider.types';
+
+@Injectable()
+export class AnthropicProvider implements AIProvider {
+  private readonly logger = new Logger(AnthropicProvider.name);
+  private client: Anthropic;
+  private config: AIProviderConfig;
+
+  constructor(config: AIProviderConfig) {
+    this.config = config;
+    this.client = new Anthropic({
+      apiKey: config.apiKey,
+    });
+  }
+
+  async generateCompletion(
+    prompt: string,
+    options?: CompletionOptions,
+  ): Promise<string> {
+    try {
+      const response = await this.client.messages.create({
+        model: options?.model || this.config.model || 'claude-sonnet-4-5-20250929',
+        max_tokens: options?.maxTokens ?? 1500,
+        temperature: options?.temperature ?? 0.7,
+        system: options?.systemPrompt,
+        messages: [{ role: 'user', content: prompt }],
+      });
+
+      const content = response.content[0];
+      if (content.type === 'text') {
+        return content.text;
+      }
+
+      return '';
+    } catch (error) {
+      this.logger.error(
+        `Anthropic completion failed: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      );
+      throw error;
+    }
+  }
+
+  async generateStructuredOutput<T>(
+    prompt: string,
+    schema: any,
+    options?: CompletionOptions,
+  ): Promise<T> {
+    try {
+      const systemPrompt =
+        options?.systemPrompt ||
+        'You are a helpful assistant that responds with valid JSON only.';
+
+      const response = await this.client.messages.create({
+        model: options?.model || this.config.model || 'claude-sonnet-4-5-20250929',
+        max_tokens: options?.maxTokens ?? 1500,
+        temperature: options?.temperature ?? 0.3,
+        system: systemPrompt,
+        messages: [
+          {
+            role: 'user',
+            content: `${prompt}\n\nRespond ONLY with valid JSON matching this schema: ${JSON.stringify(schema)}`,
+          },
+        ],
+      });
+
+      const content = response.content[0];
+      if (content.type !== 'text') {
+        throw new Error('Expected text response from Anthropic');
+      }
+
+      // Extract JSON from response (in case it's wrapped in markdown)
+      const jsonMatch = content.text.match(/\{[\s\S]*\}/);
+      if (!jsonMatch) {
+        throw new Error('No JSON found in response');
+      }
+
+      return JSON.parse(jsonMatch[0]);
+    } catch (error) {
+      this.logger.error(
+        `Anthropic structured output failed: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      );
+      throw error;
+    }
+  }
+
+  // Anthropic doesn't provide embeddings API
+  generateEmbedding?(text: string): Promise<number[]> {
+    this.logger.warn('Anthropic does not support embeddings');
+    return Promise.resolve([]);
+  }
+
+  getProviderName(): string {
+    return 'anthropic';
+  }
+
+  async validateConfig(): Promise<boolean> {
+    try {
+      // Test with minimal request
+      await this.client.messages.create({
+        model: this.config.model || 'claude-sonnet-4-5-20250929',
+        max_tokens: 10,
+        messages: [{ role: 'user', content: 'Say "ok"' }],
+      });
+      return true;
+    } catch (error) {
+      this.logger.warn(
+        `Anthropic config validation failed: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      );
+      return false;
+    }
+  }
+}

--- a/apps/api/src/ai/providers/ollama.provider.ts
+++ b/apps/api/src/ai/providers/ollama.provider.ts
@@ -1,0 +1,202 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { AIProvider, CompletionOptions } from './ai-provider.interface';
+import { AIProviderConfig } from './ai-provider.types';
+
+interface OllamaGenerateRequest {
+  model: string;
+  prompt: string;
+  stream?: boolean;
+  options?: {
+    temperature?: number;
+    num_predict?: number;
+  };
+  system?: string;
+}
+
+interface OllamaGenerateResponse {
+  model: string;
+  created_at: string;
+  response: string;
+  done: boolean;
+}
+
+interface OllamaChatRequest {
+  model: string;
+  messages: Array<{ role: string; content: string }>;
+  stream?: boolean;
+  options?: {
+    temperature?: number;
+    num_predict?: number;
+  };
+  format?: 'json';
+}
+
+interface OllamaChatResponse {
+  model: string;
+  created_at: string;
+  message: {
+    role: string;
+    content: string;
+  };
+  done: boolean;
+}
+
+interface OllamaEmbeddingRequest {
+  model: string;
+  prompt: string;
+}
+
+interface OllamaEmbeddingResponse {
+  embedding: number[];
+}
+
+@Injectable()
+export class OllamaProvider implements AIProvider {
+  private readonly logger = new Logger(OllamaProvider.name);
+  private endpoint: string;
+  private config: AIProviderConfig;
+
+  constructor(config: AIProviderConfig) {
+    this.config = config;
+    this.endpoint = config.endpoint || 'http://localhost:11434';
+  }
+
+  async generateCompletion(
+    prompt: string,
+    options?: CompletionOptions,
+  ): Promise<string> {
+    try {
+      const requestBody: OllamaChatRequest = {
+        model: options?.model || this.config.model || 'llama3.1',
+        messages: [
+          ...(options?.systemPrompt
+            ? [{ role: 'system', content: options.systemPrompt }]
+            : []),
+          { role: 'user', content: prompt },
+        ],
+        stream: false,
+        options: {
+          temperature: options?.temperature ?? 0.7,
+          num_predict: options?.maxTokens ?? 1500,
+        },
+      };
+
+      const response = await fetch(`${this.endpoint}/api/chat`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(requestBody),
+      });
+
+      if (!response.ok) {
+        throw new Error(`Ollama API error: ${response.status} ${response.statusText}`);
+      }
+
+      const data = (await response.json()) as OllamaChatResponse;
+      return data.message.content;
+    } catch (error) {
+      this.logger.error(
+        `Ollama completion failed: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      );
+      throw error;
+    }
+  }
+
+  async generateStructuredOutput<T>(
+    prompt: string,
+    schema: any,
+    options?: CompletionOptions,
+  ): Promise<T> {
+    try {
+      const systemPrompt =
+        options?.systemPrompt ||
+        'You are a helpful assistant that responds with valid JSON only.';
+
+      const requestBody: OllamaChatRequest = {
+        model: options?.model || this.config.model || 'llama3.1',
+        messages: [
+          { role: 'system', content: systemPrompt },
+          {
+            role: 'user',
+            content: `${prompt}\n\nRespond ONLY with valid JSON matching this schema: ${JSON.stringify(schema)}`,
+          },
+        ],
+        stream: false,
+        format: 'json',
+        options: {
+          temperature: options?.temperature ?? 0.3,
+          num_predict: options?.maxTokens ?? 1500,
+        },
+      };
+
+      const response = await fetch(`${this.endpoint}/api/chat`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(requestBody),
+      });
+
+      if (!response.ok) {
+        throw new Error(`Ollama API error: ${response.status} ${response.statusText}`);
+      }
+
+      const data = (await response.json()) as OllamaChatResponse;
+      const content = data.message.content;
+
+      // Extract JSON from response
+      const jsonMatch = content.match(/\{[\s\S]*\}/);
+      if (!jsonMatch) {
+        throw new Error('No JSON found in response');
+      }
+
+      return JSON.parse(jsonMatch[0]);
+    } catch (error) {
+      this.logger.error(
+        `Ollama structured output failed: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      );
+      throw error;
+    }
+  }
+
+  async generateEmbedding(text: string): Promise<number[]> {
+    try {
+      const requestBody: OllamaEmbeddingRequest = {
+        model: this.config.model || 'llama3.1',
+        prompt: text,
+      };
+
+      const response = await fetch(`${this.endpoint}/api/embeddings`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(requestBody),
+      });
+
+      if (!response.ok) {
+        throw new Error(`Ollama API error: ${response.status} ${response.statusText}`);
+      }
+
+      const data = (await response.json()) as OllamaEmbeddingResponse;
+      return data.embedding;
+    } catch (error) {
+      this.logger.error(
+        `Ollama embedding failed: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      );
+      return [];
+    }
+  }
+
+  getProviderName(): string {
+    return 'ollama';
+  }
+
+  async validateConfig(): Promise<boolean> {
+    try {
+      // Test connection by listing models
+      const response = await fetch(`${this.endpoint}/api/tags`);
+      return response.ok;
+    } catch (error) {
+      this.logger.warn(
+        `Ollama config validation failed: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      );
+      return false;
+    }
+  }
+}

--- a/apps/api/src/ai/providers/openai.provider.ts
+++ b/apps/api/src/ai/providers/openai.provider.ts
@@ -1,0 +1,127 @@
+import { Injectable, Logger } from '@nestjs/common';
+import OpenAI from 'openai';
+import { AIProvider, CompletionOptions } from './ai-provider.interface';
+import { AIProviderConfig } from './ai-provider.types';
+
+@Injectable()
+export class OpenAIProvider implements AIProvider {
+  private readonly logger = new Logger(OpenAIProvider.name);
+  private client: OpenAI;
+  private config: AIProviderConfig;
+
+  constructor(config: AIProviderConfig) {
+    this.config = config;
+    this.client = new OpenAI({
+      apiKey: config.apiKey,
+      organization: config.organizationId,
+    });
+  }
+
+  async generateCompletion(
+    prompt: string,
+    options?: CompletionOptions,
+  ): Promise<string> {
+    try {
+      const response = await this.client.chat.completions.create({
+        model: options?.model || this.config.model || 'gpt-4o',
+        messages: [
+          ...(options?.systemPrompt
+            ? [{ role: 'system' as const, content: options.systemPrompt }]
+            : []),
+          { role: 'user' as const, content: prompt },
+        ],
+        temperature: options?.temperature ?? 0.7,
+        max_tokens: options?.maxTokens ?? 1500,
+      });
+
+      return response.choices[0].message.content || '';
+    } catch (error) {
+      this.logger.error(
+        `OpenAI completion failed: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      );
+      throw error;
+    }
+  }
+
+  async generateStructuredOutput<T>(
+    prompt: string,
+    schema: any,
+    options?: CompletionOptions,
+  ): Promise<T> {
+    try {
+      const systemPrompt =
+        options?.systemPrompt ||
+        'You are a helpful assistant that responds with valid JSON only.';
+
+      const response = await this.client.chat.completions.create({
+        model: options?.model || this.config.model || 'gpt-4o',
+        messages: [
+          { role: 'system', content: systemPrompt },
+          {
+            role: 'user',
+            content: `${prompt}\n\nRespond ONLY with valid JSON matching this schema: ${JSON.stringify(schema)}`,
+          },
+        ],
+        temperature: options?.temperature ?? 0.3,
+        max_tokens: options?.maxTokens ?? 1500,
+        response_format: { type: 'json_object' },
+      });
+
+      const content = response.choices[0].message.content;
+      if (!content) {
+        throw new Error('Empty response from OpenAI');
+      }
+
+      // Extract JSON from response (in case it's wrapped)
+      const jsonMatch = content.match(/\{[\s\S]*\}/);
+      if (!jsonMatch) {
+        throw new Error('No JSON found in response');
+      }
+
+      return JSON.parse(jsonMatch[0]);
+    } catch (error) {
+      this.logger.error(
+        `OpenAI structured output failed: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      );
+      throw error;
+    }
+  }
+
+  async generateEmbedding(text: string): Promise<number[]> {
+    try {
+      const EMBEDDING_MAX_CHARS = 32000;
+      const truncated =
+        text.length > EMBEDDING_MAX_CHARS
+          ? text.slice(0, EMBEDDING_MAX_CHARS)
+          : text;
+
+      const response = await this.client.embeddings.create({
+        model: 'text-embedding-3-small',
+        input: truncated,
+      });
+
+      return response.data[0].embedding;
+    } catch (error) {
+      this.logger.error(
+        `OpenAI embedding failed: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      );
+      return [];
+    }
+  }
+
+  getProviderName(): string {
+    return 'openai';
+  }
+
+  async validateConfig(): Promise<boolean> {
+    try {
+      await this.client.models.list();
+      return true;
+    } catch (error) {
+      this.logger.warn(
+        `OpenAI config validation failed: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      );
+      return false;
+    }
+  }
+}

--- a/apps/api/src/modules/ai-config/ai-config.controller.ts
+++ b/apps/api/src/modules/ai-config/ai-config.controller.ts
@@ -35,8 +35,9 @@ export class AiConfigController {
       return {
         configured: false,
         provider: 'anthropic',
-        model: 'claude-sonnet-4-20250514',
+        model: 'claude-sonnet-4-5-20250929',
         maskedApiKey: null,
+        endpoint: null,
         settings: {},
       };
     }
@@ -57,7 +58,7 @@ export class AiConfigController {
   }
 
   @Post('validate-key')
-  @ApiOperation({ summary: 'Validate an Anthropic API key' })
+  @ApiOperation({ summary: 'Validate an AI provider API key/configuration' })
   @ApiResponse({
     status: 200,
     description: 'Validation result',
@@ -70,6 +71,11 @@ export class AiConfigController {
   })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   async validateKey(@Body() dto: ValidateKeyDto) {
-    return this.aiConfigService.validateKey(dto.apiKey);
+    return this.aiConfigService.validateKey(
+      dto.apiKey,
+      dto.provider,
+      dto.endpoint,
+      dto.model,
+    );
   }
 }

--- a/apps/api/src/modules/ai-config/ai-config.module.ts
+++ b/apps/api/src/modules/ai-config/ai-config.module.ts
@@ -2,12 +2,13 @@ import { Module } from '@nestjs/common';
 import { AiConfigController } from './ai-config.controller';
 import { AiConfigService } from './ai-config.service';
 import { AnthropicClientFactory } from './anthropic-client.factory';
+import { AIProviderFactory } from '../../ai/providers/ai-provider.factory';
 import { PrismaModule } from '../../prisma/prisma.module';
 
 @Module({
   imports: [PrismaModule],
   controllers: [AiConfigController],
-  providers: [AiConfigService, AnthropicClientFactory],
+  providers: [AiConfigService, AnthropicClientFactory, AIProviderFactory],
   exports: [AiConfigService, AnthropicClientFactory],
 })
 export class AiConfigModule {}

--- a/apps/api/src/modules/ai-config/ai-config.service.ts
+++ b/apps/api/src/modules/ai-config/ai-config.service.ts
@@ -1,7 +1,8 @@
 import { Injectable, Logger, BadRequestException } from '@nestjs/common';
 import { PrismaService } from '../../prisma/prisma.service';
-import { UpdateAiConfigDto } from './dto/update-ai-config.dto';
-import Anthropic from '@anthropic-ai/sdk';
+import { UpdateAiConfigDto, AIProviderType } from './dto/update-ai-config.dto';
+import { AIProviderFactory } from '../../ai/providers/ai-provider.factory';
+import { AIProviderConfig } from '../../ai/providers/ai-provider.types';
 
 export interface AiConfigResponse {
   id: string;
@@ -9,6 +10,7 @@ export interface AiConfigResponse {
   provider: string;
   maskedApiKey: string | null;
   model: string;
+  endpoint?: string;
   settings: Record<string, any>;
   createdAt: Date;
   updatedAt: Date;
@@ -20,6 +22,7 @@ export class AiConfigService {
 
   constructor(
     private readonly prisma: PrismaService,
+    private readonly providerFactory: AIProviderFactory,
   ) {}
 
   async getConfig(tenantId: string): Promise<AiConfigResponse | null> {
@@ -32,13 +35,16 @@ export class AiConfigService {
     }
 
     // encryptedApiKey is auto-decrypted by Prisma encryption middleware
+    const settings = config.settings as Record<string, any>;
+
     return {
       id: config.id,
       tenantId: config.tenantId,
       provider: config.provider,
       maskedApiKey: this.maskApiKey(config.encryptedApiKey),
       model: config.model,
-      settings: config.settings as Record<string, any>,
+      endpoint: settings?.endpoint,
+      settings,
       createdAt: config.createdAt,
       updatedAt: config.updatedAt,
     };
@@ -48,8 +54,15 @@ export class AiConfigService {
     tenantId: string,
     dto: UpdateAiConfigDto,
   ): Promise<AiConfigResponse> {
+    const existing = await this.prisma.aiConfig.findUnique({
+      where: { tenantId },
+    });
+
     const data: any = {};
 
+    if (dto.provider !== undefined) {
+      data.provider = dto.provider;
+    }
     if (dto.apiKey) {
       // Prisma encryption middleware will auto-encrypt on write
       data.encryptedApiKey = dto.apiKey;
@@ -57,13 +70,16 @@ export class AiConfigService {
     if (dto.model !== undefined) {
       data.model = dto.model;
     }
-    if (dto.settings !== undefined) {
-      data.settings = dto.settings;
-    }
 
-    const existing = await this.prisma.aiConfig.findUnique({
-      where: { tenantId },
-    });
+    // Merge endpoint and other settings
+    const mergedSettings: Record<string, any> = {
+      ...(existing?.settings as Record<string, any>),
+      ...dto.settings,
+    };
+    if (dto.endpoint !== undefined) {
+      mergedSettings.endpoint = dto.endpoint;
+    }
+    data.settings = mergedSettings;
 
     let config;
 
@@ -73,45 +89,80 @@ export class AiConfigService {
         data,
       });
     } else {
-      if (!dto.apiKey) {
+      // Create new config
+      const provider = dto.provider || AIProviderType.ANTHROPIC;
+
+      // Ollama doesn't require API key
+      if (provider !== AIProviderType.OLLAMA && !dto.apiKey) {
         throw new BadRequestException(
-          'API key is required when creating a new AI configuration',
+          `API key is required for ${provider} provider`,
         );
       }
+
       config = await this.prisma.aiConfig.create({
         data: {
           tenantId,
-          encryptedApiKey: data.encryptedApiKey,
-          model: dto.model || 'claude-sonnet-4-20250514',
-          settings: dto.settings || {},
+          provider,
+          encryptedApiKey: dto.apiKey || '',
+          model: dto.model || this.getDefaultModel(provider),
+          settings: mergedSettings,
         },
       });
     }
 
-    // encryptedApiKey is auto-decrypted by Prisma encryption middleware
+    const settings = config.settings as Record<string, any>;
+
     return {
       id: config.id,
       tenantId: config.tenantId,
       provider: config.provider,
       maskedApiKey: this.maskApiKey(config.encryptedApiKey),
       model: config.model,
-      settings: config.settings as Record<string, any>,
+      endpoint: settings?.endpoint,
+      settings,
       createdAt: config.createdAt,
       updatedAt: config.updatedAt,
     };
   }
 
+  private getDefaultModel(provider: AIProviderType): string {
+    switch (provider) {
+      case AIProviderType.OPENAI:
+        return 'gpt-4o';
+      case AIProviderType.ANTHROPIC:
+        return 'claude-sonnet-4-5-20250929';
+      case AIProviderType.OLLAMA:
+        return 'llama3.1';
+      default:
+        return 'claude-sonnet-4-5-20250929';
+    }
+  }
+
   async validateKey(
     apiKey: string,
+    provider?: AIProviderType,
+    endpoint?: string,
+    model?: string,
   ): Promise<{ valid: boolean; error?: string }> {
     try {
-      const client = new Anthropic({ apiKey });
+      const providerType = provider || AIProviderType.ANTHROPIC;
 
-      await client.messages.create({
-        model: 'claude-sonnet-4-20250514',
-        max_tokens: 10,
-        messages: [{ role: 'user', content: 'Say "ok"' }],
-      });
+      const config: AIProviderConfig = {
+        provider: providerType as any,
+        apiKey,
+        endpoint,
+        model,
+      };
+
+      const providerInstance = this.providerFactory.create(config);
+      const isValid = await providerInstance.validateConfig();
+
+      if (!isValid) {
+        return {
+          valid: false,
+          error: `Failed to validate ${providerType} configuration`,
+        };
+      }
 
       return { valid: true };
     } catch (error: any) {
@@ -121,7 +172,10 @@ export class AiConfigService {
         return { valid: false, error: 'Invalid API key' };
       }
       if (error.status === 403) {
-        return { valid: false, error: 'API key does not have required permissions' };
+        return {
+          valid: false,
+          error: 'API key does not have required permissions',
+        };
       }
       if (error.status === 429) {
         // Rate-limited but the key itself is valid
@@ -130,7 +184,7 @@ export class AiConfigService {
 
       return {
         valid: false,
-        error: error.message || 'Failed to validate API key',
+        error: error.message || 'Failed to validate configuration',
       };
     }
   }

--- a/apps/api/src/modules/ai-config/dto/update-ai-config.dto.ts
+++ b/apps/api/src/modules/ai-config/dto/update-ai-config.dto.ts
@@ -1,9 +1,24 @@
-import { IsString, IsOptional, IsObject } from 'class-validator';
+import { IsString, IsOptional, IsObject, IsEnum } from 'class-validator';
 import { ApiPropertyOptional } from '@nestjs/swagger';
+
+export enum AIProviderType {
+  OPENAI = 'openai',
+  ANTHROPIC = 'anthropic',
+  OLLAMA = 'ollama',
+}
 
 export class UpdateAiConfigDto {
   @ApiPropertyOptional({
-    description: 'Anthropic API key (sk-ant-...)',
+    description: 'AI provider type',
+    enum: AIProviderType,
+    example: AIProviderType.ANTHROPIC,
+  })
+  @IsOptional()
+  @IsEnum(AIProviderType)
+  provider?: AIProviderType;
+
+  @ApiPropertyOptional({
+    description: 'API key for the provider (not required for Ollama)',
     example: 'sk-ant-api03-...',
   })
   @IsOptional()
@@ -12,11 +27,19 @@ export class UpdateAiConfigDto {
 
   @ApiPropertyOptional({
     description: 'Model identifier',
-    example: 'claude-sonnet-4-20250514',
+    example: 'claude-sonnet-4-5-20250929',
   })
   @IsOptional()
   @IsString()
   model?: string;
+
+  @ApiPropertyOptional({
+    description: 'Endpoint URL (for Ollama or custom endpoints)',
+    example: 'http://localhost:11434',
+  })
+  @IsOptional()
+  @IsString()
+  endpoint?: string;
 
   @ApiPropertyOptional({
     description: 'Additional settings (e.g. max tokens, temperature)',

--- a/apps/api/src/modules/ai-config/dto/validate-key.dto.ts
+++ b/apps/api/src/modules/ai-config/dto/validate-key.dto.ts
@@ -1,11 +1,37 @@
-import { IsString } from 'class-validator';
-import { ApiProperty } from '@nestjs/swagger';
+import { IsString, IsOptional, IsEnum } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { AIProviderType } from './update-ai-config.dto';
 
 export class ValidateKeyDto {
   @ApiProperty({
-    description: 'Anthropic API key to validate',
+    description: 'API key to validate',
     example: 'sk-ant-api03-...',
   })
   @IsString()
   apiKey: string;
+
+  @ApiPropertyOptional({
+    description: 'AI provider type',
+    enum: AIProviderType,
+    example: AIProviderType.ANTHROPIC,
+  })
+  @IsOptional()
+  @IsEnum(AIProviderType)
+  provider?: AIProviderType;
+
+  @ApiPropertyOptional({
+    description: 'Endpoint URL (for Ollama)',
+    example: 'http://localhost:11434',
+  })
+  @IsOptional()
+  @IsString()
+  endpoint?: string;
+
+  @ApiPropertyOptional({
+    description: 'Model to test',
+    example: 'claude-sonnet-4-5-20250929',
+  })
+  @IsOptional()
+  @IsString()
+  model?: string;
 }

--- a/apps/dashboard/app/dashboard/settings/ai/page.tsx
+++ b/apps/dashboard/app/dashboard/settings/ai/page.tsx
@@ -6,13 +6,54 @@ import { DashboardLayout } from '@/components/layout/DashboardLayout';
 import { PageLoader, Card, Button, Input, Select } from '@/components/ui';
 import { aiConfigApi, type AiConfigResponse } from '@/lib/api/ai-config';
 
-const MODEL_OPTIONS = [
-  { value: 'claude-sonnet-4-20250514', label: 'Claude Sonnet 4 (Recommended)' },
-  { value: 'claude-opus-4-20250514', label: 'Claude Opus 4' },
-  { value: 'claude-haiku-4-20250514', label: 'Claude Haiku 4 (Fast)' },
-];
+// Provider types
+type AIProviderType = 'openai' | 'anthropic' | 'ollama';
 
-type KeyStatus = 'idle' | 'testing' | 'valid' | 'invalid';
+// Model options by provider
+const MODEL_OPTIONS = {
+  openai: [
+    { value: 'gpt-4o', label: 'GPT-4o (Recommended)' },
+    { value: 'gpt-4-turbo', label: 'GPT-4 Turbo' },
+    { value: 'gpt-3.5-turbo', label: 'GPT-3.5 Turbo (Fast)' },
+  ],
+  anthropic: [
+    { value: 'claude-sonnet-4-5-20250929', label: 'Claude Sonnet 4.5 (Recommended)' },
+    { value: 'claude-haiku-4-5-20251001', label: 'Claude Haiku 4.5 (Fast)' },
+  ],
+  ollama: [
+    { value: 'llama3.1', label: 'Llama 3.1 (Default)' },
+    { value: 'llama3.2', label: 'Llama 3.2' },
+    { value: 'mistral', label: 'Mistral' },
+    { value: 'codellama', label: 'CodeLlama' },
+  ],
+};
+
+// Provider info
+const PROVIDER_INFO = {
+  openai: {
+    name: 'OpenAI',
+    description: 'Industry-leading models with exceptional reasoning capabilities',
+    icon: '🧠',
+    requiresApiKey: true,
+    defaultEndpoint: 'https://api.openai.com/v1',
+  },
+  anthropic: {
+    name: 'Anthropic',
+    description: 'Claude models with advanced context understanding and safety',
+    icon: '✨',
+    requiresApiKey: true,
+    defaultEndpoint: 'https://api.anthropic.com/v1',
+  },
+  ollama: {
+    name: 'Ollama (Local)',
+    description: 'Run AI models locally on your own hardware for privacy',
+    icon: '🖥️',
+    requiresApiKey: false,
+    defaultEndpoint: 'http://localhost:11434',
+  },
+};
+
+type TestStatus = 'idle' | 'testing' | 'success' | 'error';
 
 export default function AiSettingsPage() {
   const { isLoading: authLoading } = useRequireAuth();
@@ -22,12 +63,16 @@ export default function AiSettingsPage() {
   const [saving, setSaving] = useState(false);
 
   // Form state
+  const [provider, setProvider] = useState<AIProviderType>('anthropic');
   const [apiKey, setApiKey] = useState('');
-  const [model, setModel] = useState('claude-sonnet-4-20250514');
+  const [showApiKey, setShowApiKey] = useState(false);
+  const [model, setModel] = useState('');
+  const [endpoint, setEndpoint] = useState('');
+  const [organizationId, setOrganizationId] = useState('');
 
-  // Validation state
-  const [keyStatus, setKeyStatus] = useState<KeyStatus>('idle');
-  const [keyError, setKeyError] = useState<string | null>(null);
+  // Test connection state
+  const [testStatus, setTestStatus] = useState<TestStatus>('idle');
+  const [testMessage, setTestMessage] = useState<string | null>(null);
 
   // Toast
   const [toast, setToast] = useState<{
@@ -51,8 +96,25 @@ export default function AiSettingsPage() {
       try {
         const data = await aiConfigApi.getConfig();
         setConfig(data);
-        setModel(data.model || 'claude-sonnet-4-20250514');
-      } catch {
+
+        // Set form values from config
+        const currentProvider = (data.provider || 'anthropic') as AIProviderType;
+        setProvider(currentProvider);
+        const defaultModel = MODEL_OPTIONS[currentProvider]?.[0]?.value || '';
+        setModel(data.model || defaultModel);
+
+        // Set endpoint for Ollama
+        if (currentProvider === 'ollama' && data.settings?.endpoint) {
+          setEndpoint(data.settings.endpoint);
+        } else if (currentProvider === 'ollama') {
+          setEndpoint(PROVIDER_INFO.ollama.defaultEndpoint);
+        }
+
+        // Set organization ID for OpenAI
+        if (currentProvider === 'openai' && data.settings?.organizationId) {
+          setOrganizationId(data.settings.organizationId);
+        }
+      } catch (err) {
         showToast('error', 'Failed to load AI configuration');
       } finally {
         setLoading(false);
@@ -61,24 +123,75 @@ export default function AiSettingsPage() {
     loadConfig();
   }, [authLoading, showToast]);
 
-  // Validate key
-  const handleValidateKey = async () => {
-    if (!apiKey.trim()) return;
+  // Update defaults when provider changes
+  const handleProviderChange = (newProvider: AIProviderType) => {
+    setProvider(newProvider);
+    const defaultModel = MODEL_OPTIONS[newProvider]?.[0]?.value || '';
+    setModel(defaultModel);
+    setApiKey('');
+    setShowApiKey(false);
+    setTestStatus('idle');
+    setTestMessage(null);
 
-    setKeyStatus('testing');
-    setKeyError(null);
+    // Set default endpoint for Ollama
+    if (newProvider === 'ollama') {
+      setEndpoint(PROVIDER_INFO.ollama.defaultEndpoint);
+    } else {
+      setEndpoint('');
+    }
+
+    // Clear organization ID when not OpenAI
+    if (newProvider !== 'openai') {
+      setOrganizationId('');
+    }
+  };
+
+  // Test connection
+  const handleTestConnection = async () => {
+    setTestStatus('testing');
+    setTestMessage(null);
 
     try {
-      const result = await aiConfigApi.validateKey(apiKey);
-      if (result.valid) {
-        setKeyStatus('valid');
-      } else {
-        setKeyStatus('invalid');
-        setKeyError(result.error || 'Invalid API key');
+      const testPayload: any = {
+        provider,
+        model,
+      };
+
+      if (apiKey.trim()) {
+        testPayload.apiKey = apiKey;
       }
-    } catch {
-      setKeyStatus('invalid');
-      setKeyError('Failed to validate key');
+
+      if (provider === 'ollama' && endpoint) {
+        testPayload.endpoint = endpoint;
+      }
+
+      if (provider === 'openai' && organizationId) {
+        testPayload.organizationId = organizationId;
+      }
+
+      // Use testConnection if new API endpoint exists, fallback to validateKey
+      let result;
+      try {
+        result = await aiConfigApi.testConnection(testPayload);
+      } catch (err: any) {
+        // Fallback to legacy validateKey endpoint if testConnection not available
+        if (err.statusCode === 404 && testPayload.apiKey) {
+          result = await aiConfigApi.validateKey(testPayload.apiKey);
+        } else {
+          throw err;
+        }
+      }
+
+      if (result.valid) {
+        setTestStatus('success');
+        setTestMessage('Connection successful! AI provider is responding correctly.');
+      } else {
+        setTestStatus('error');
+        setTestMessage(result.error || 'Connection failed');
+      }
+    } catch (err: any) {
+      setTestStatus('error');
+      setTestMessage(err.message || 'Failed to test connection');
     }
   };
 
@@ -88,22 +201,40 @@ export default function AiSettingsPage() {
     setSaving(true);
 
     try {
-      const payload: { apiKey?: string; model?: string } = { model };
-      if (apiKey.trim()) {
+      const payload: any = {
+        provider,
+        model,
+      };
+
+      // Add API key if provided
+      if (apiKey.trim() && PROVIDER_INFO[provider].requiresApiKey) {
         payload.apiKey = apiKey;
+      }
+
+      // Add provider-specific settings
+      const settings: any = {};
+
+      if (provider === 'ollama' && endpoint) {
+        settings.endpoint = endpoint;
+      }
+
+      if (provider === 'openai' && organizationId) {
+        settings.organizationId = organizationId;
+      }
+
+      if (Object.keys(settings).length > 0) {
+        payload.settings = settings;
       }
 
       const updated = await aiConfigApi.updateConfig(payload);
       setConfig(updated);
       setApiKey('');
-      setKeyStatus('idle');
-      setKeyError(null);
+      setShowApiKey(false);
+      setTestStatus('idle');
+      setTestMessage(null);
       showToast('success', 'AI configuration saved successfully');
     } catch (err: any) {
-      showToast(
-        'error',
-        err.message || 'Failed to save AI configuration'
-      );
+      showToast('error', err.message || 'Failed to save AI configuration');
     } finally {
       setSaving(false);
     }
@@ -113,26 +244,29 @@ export default function AiSettingsPage() {
     return <PageLoader />;
   }
 
+  const currentProviderInfo = PROVIDER_INFO[provider];
+  const isConfigured = config?.configured && config?.provider === provider;
+
   return (
     <DashboardLayout>
-      <div className="max-w-3xl mx-auto">
+      <div className="max-w-4xl mx-auto">
         {/* Toast */}
         {toast && (
           <div
             className={`fixed top-4 right-4 z-50 px-4 py-3 rounded-lg shadow-lg transition-all ${
               toast.type === 'success'
-                ? 'bg-green-50 border border-green-200 text-green-800'
-                : 'bg-red-50 border border-red-200 text-red-800'
+                ? 'bg-green-50 border border-green-200 text-green-800 dark:bg-green-900/20 dark:border-green-800 dark:text-green-300'
+                : 'bg-red-50 border border-red-200 text-red-800 dark:bg-red-900/20 dark:border-red-800 dark:text-red-300'
             }`}
           >
             <div className="flex items-center space-x-2">
-              <span>{toast.type === 'success' ? 'OK' : '!'}</span>
+              <span>{toast.type === 'success' ? '✓' : '✕'}</span>
               <span className="text-sm font-medium">{toast.message}</span>
               <button
                 onClick={() => setToast(null)}
-                className="ml-2 text-gray-400 hover:text-gray-600"
+                className="ml-2 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
               >
-                x
+                ×
               </button>
             </div>
           </div>
@@ -143,139 +277,258 @@ export default function AiSettingsPage() {
           <div className="flex items-center space-x-3 mb-2">
             <a
               href="/dashboard/settings"
-              className="text-sm text-gray-500 hover:text-gray-700"
+              className="text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200"
             >
               Settings
             </a>
-            <span className="text-gray-300">/</span>
-            <span className="text-sm text-gray-900 font-medium">AI</span>
+            <span className="text-gray-300 dark:text-gray-600">/</span>
+            <span className="text-sm text-gray-900 dark:text-white font-medium">AI</span>
           </div>
-          <h1 className="text-3xl font-bold text-gray-900">
+          <h1 className="text-3xl font-bold text-gray-900 dark:text-white">
             AI Configuration
           </h1>
-          <p className="text-gray-600 mt-1">
-            Configure your Anthropic API key to enable AI-powered features like
-            ticket analysis, agent conversations, and automated classification.
+          <p className="text-gray-600 dark:text-gray-400 mt-1">
+            Configure your AI provider to enable intelligent features like ticket analysis,
+            agent conversations, and automated classification.
           </p>
         </div>
 
-        {/* Status Card */}
-        <Card>
-          <div className="flex items-center justify-between mb-6">
-            <div className="flex items-center space-x-3">
-              <div
-                className={`w-3 h-3 rounded-full ${
-                  config?.configured ? 'bg-green-500' : 'bg-gray-300'
-                }`}
-              />
-              <span className="text-sm font-medium text-gray-900">
-                {config?.configured
-                  ? 'AI is configured and ready'
-                  : 'AI is not configured'}
-              </span>
-            </div>
-            {config?.configured && config.maskedApiKey && (
-              <span className="text-sm text-gray-500 font-mono">
-                Key: {config.maskedApiKey}
-              </span>
-            )}
-          </div>
+        {/* Provider Selection */}
+        <div className="mb-6">
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">
+            Select AI Provider
+          </h2>
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+            {(Object.keys(PROVIDER_INFO) as AIProviderType[]).map((providerKey) => {
+              const info = PROVIDER_INFO[providerKey];
+              const isSelected = provider === providerKey;
 
-          {!config?.configured && (
-            <div className="bg-blue-50 border border-blue-200 rounded-lg p-4 mb-6">
-              <p className="text-sm text-blue-800">
-                Configure your Anthropic API key to enable the AI agent. You
-                can obtain a key from{' '}
-                <a
-                  href="https://console.anthropic.com/settings/keys"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="underline font-medium"
-                >
-                  console.anthropic.com
-                </a>
-                .
-              </p>
-            </div>
-          )}
-
-          <form onSubmit={handleSave} className="space-y-6">
-            {/* API Key */}
-            <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">
-                API Key
-              </label>
-              <div className="flex gap-3">
-                <div className="flex-1">
-                  <Input
-                    type="password"
-                    value={apiKey}
-                    onChange={(e) => {
-                      setApiKey(e.target.value);
-                      setKeyStatus('idle');
-                      setKeyError(null);
-                    }}
-                    placeholder={
-                      config?.configured
-                        ? 'Enter new key to replace existing one'
-                        : 'sk-ant-api03-...'
-                    }
-                    disabled={saving}
-                  />
-                </div>
-                <Button
+              return (
+                <button
+                  key={providerKey}
                   type="button"
-                  variant="secondary"
-                  onClick={handleValidateKey}
-                  disabled={!apiKey.trim() || keyStatus === 'testing'}
-                  isLoading={keyStatus === 'testing'}
+                  onClick={() => handleProviderChange(providerKey)}
+                  className={`p-4 rounded-lg border-2 transition-all text-left ${
+                    isSelected
+                      ? 'border-blue-500 bg-blue-50 dark:bg-blue-900/20'
+                      : 'border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 hover:border-gray-400 dark:hover:border-gray-500'
+                  }`}
                 >
-                  Validate
-                </Button>
-              </div>
+                  <div className="flex items-start space-x-3">
+                    <div className="text-3xl">{info.icon}</div>
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center justify-between">
+                        <h3 className="font-semibold text-gray-900 dark:text-white">
+                          {info.name}
+                        </h3>
+                        {isSelected && (
+                          <svg className="w-5 h-5 text-blue-500" fill="currentColor" viewBox="0 0 20 20">
+                            <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" />
+                          </svg>
+                        )}
+                      </div>
+                      <p className="text-sm text-gray-600 dark:text-gray-400 mt-1">
+                        {info.description}
+                      </p>
+                    </div>
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+        </div>
 
-              {/* Validation feedback */}
-              {keyStatus === 'valid' && (
-                <p className="mt-2 text-sm text-green-600 font-medium">
-                  API key is valid
-                </p>
-              )}
-              {keyStatus === 'invalid' && keyError && (
-                <p className="mt-2 text-sm text-red-600 font-medium">
-                  {keyError}
-                </p>
+        {/* Configuration Form */}
+        <Card>
+          <form onSubmit={handleSave} className="space-y-6">
+            {/* Status indicator */}
+            <div className="flex items-center justify-between pb-4 border-b border-gray-200 dark:border-gray-700">
+              <div className="flex items-center space-x-3">
+                <div
+                  className={`w-3 h-3 rounded-full ${
+                    isConfigured ? 'bg-green-500' : 'bg-gray-300 dark:bg-gray-600'
+                  }`}
+                />
+                <span className="text-sm font-medium text-gray-900 dark:text-white">
+                  {isConfigured
+                    ? `${currentProviderInfo.name} is configured and ready`
+                    : `${currentProviderInfo.name} is not configured`}
+                </span>
+              </div>
+              {isConfigured && config?.maskedApiKey && (
+                <span className="text-sm text-gray-500 dark:text-gray-400 font-mono">
+                  Key: {config.maskedApiKey}
+                </span>
               )}
             </div>
+
+            {/* API Key (if required) */}
+            {currentProviderInfo.requiresApiKey && (
+              <div>
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                  API Key
+                </label>
+                <div className="flex gap-3">
+                  <div className="flex-1 relative">
+                    <Input
+                      type={showApiKey ? 'text' : 'password'}
+                      value={apiKey}
+                      onChange={(e) => {
+                        setApiKey(e.target.value);
+                        setTestStatus('idle');
+                        setTestMessage(null);
+                      }}
+                      placeholder={
+                        isConfigured
+                          ? 'Enter new key to replace existing one'
+                          : provider === 'openai'
+                          ? 'sk-proj-...'
+                          : 'sk-ant-api03-...'
+                      }
+                      disabled={saving}
+                    />
+                    <button
+                      type="button"
+                      onClick={() => setShowApiKey(!showApiKey)}
+                      className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
+                      tabIndex={-1}
+                    >
+                      {showApiKey ? (
+                        <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21" />
+                        </svg>
+                      ) : (
+                        <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+                        </svg>
+                      )}
+                    </button>
+                  </div>
+                </div>
+                <p className="mt-2 text-sm text-gray-500 dark:text-gray-400">
+                  {provider === 'openai' && (
+                    <>
+                      Get your API key from{' '}
+                      <a
+                        href="https://platform.openai.com/api-keys"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-blue-600 dark:text-blue-400 hover:underline"
+                      >
+                        platform.openai.com
+                      </a>
+                    </>
+                  )}
+                  {provider === 'anthropic' && (
+                    <>
+                      Get your API key from{' '}
+                      <a
+                        href="https://console.anthropic.com/settings/keys"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-blue-600 dark:text-blue-400 hover:underline"
+                      >
+                        console.anthropic.com
+                      </a>
+                    </>
+                  )}
+                </p>
+              </div>
+            )}
+
+            {/* Endpoint (for Ollama) */}
+            {provider === 'ollama' && (
+              <Input
+                label="Endpoint URL"
+                type="url"
+                value={endpoint}
+                onChange={(e) => setEndpoint(e.target.value)}
+                placeholder="http://localhost:11434"
+                helperText="URL of your Ollama server"
+                disabled={saving}
+              />
+            )}
+
+            {/* Organization ID (for OpenAI) */}
+            {provider === 'openai' && (
+              <Input
+                label="Organization ID (Optional)"
+                type="text"
+                value={organizationId}
+                onChange={(e) => setOrganizationId(e.target.value)}
+                placeholder="org-..."
+                helperText="Required only if you belong to multiple organizations"
+                disabled={saving}
+              />
+            )}
 
             {/* Model Selector */}
             <Select
               label="Model"
-              options={MODEL_OPTIONS}
+              options={MODEL_OPTIONS[provider]}
               value={model}
               onChange={(e) => setModel(e.target.value)}
               disabled={saving}
             />
 
+            {/* Test Connection */}
+            <div className="pt-4 border-t border-gray-200 dark:border-gray-700">
+              <div className="flex items-center justify-between mb-3">
+                <h3 className="text-sm font-medium text-gray-900 dark:text-white">
+                  Test Connection
+                </h3>
+                <Button
+                  type="button"
+                  variant="secondary"
+                  onClick={handleTestConnection}
+                  disabled={
+                    testStatus === 'testing' ||
+                    (currentProviderInfo.requiresApiKey && !apiKey.trim() && !isConfigured)
+                  }
+                  isLoading={testStatus === 'testing'}
+                >
+                  Test Connection
+                </Button>
+              </div>
+
+              {/* Test feedback */}
+              {testStatus === 'success' && testMessage && (
+                <div className="p-3 rounded-lg bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800">
+                  <p className="text-sm text-green-800 dark:text-green-300 font-medium">
+                    ✓ {testMessage}
+                  </p>
+                </div>
+              )}
+              {testStatus === 'error' && testMessage && (
+                <div className="p-3 rounded-lg bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800">
+                  <p className="text-sm text-red-800 dark:text-red-300 font-medium">
+                    ✕ {testMessage}
+                  </p>
+                </div>
+              )}
+            </div>
+
             {/* Current config info */}
-            {config?.configured && (
-              <div className="bg-gray-50 rounded-lg p-4 space-y-2">
+            {isConfigured && (
+              <div className="bg-gray-50 dark:bg-gray-800 rounded-lg p-4 space-y-2">
                 <div className="flex justify-between text-sm">
-                  <span className="text-gray-600">Provider</span>
-                  <span className="font-medium text-gray-900 capitalize">
-                    {config.provider}
+                  <span className="text-gray-600 dark:text-gray-400">Provider</span>
+                  <span className="font-medium text-gray-900 dark:text-white capitalize">
+                    {currentProviderInfo.name}
                   </span>
                 </div>
                 <div className="flex justify-between text-sm">
-                  <span className="text-gray-600">Current Model</span>
-                  <span className="font-medium text-gray-900">
+                  <span className="text-gray-600 dark:text-gray-400">Current Model</span>
+                  <span className="font-medium text-gray-900 dark:text-white">
                     {config.model}
                   </span>
                 </div>
                 {config.updatedAt && (
                   <div className="flex justify-between text-sm">
-                    <span className="text-gray-600">Last Updated</span>
-                    <span className="font-medium text-gray-900">
-                      {new Date(config.updatedAt).toLocaleDateString('fr-FR', {
+                    <span className="text-gray-600 dark:text-gray-400">Last Updated</span>
+                    <span className="font-medium text-gray-900 dark:text-white">
+                      {new Date(config.updatedAt).toLocaleDateString('en-US', {
                         year: 'numeric',
                         month: 'long',
                         day: 'numeric',
@@ -289,10 +542,24 @@ export default function AiSettingsPage() {
             )}
 
             {/* Actions */}
-            <div className="flex gap-3 pt-4 border-t">
+            <div className="flex gap-3 pt-4 border-t border-gray-200 dark:border-gray-700">
               <Button type="submit" isLoading={saving}>
-                {config?.configured ? 'Update Configuration' : 'Save Configuration'}
+                {isConfigured ? 'Update Configuration' : 'Save Configuration'}
               </Button>
+              {!isConfigured && (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  onClick={() => {
+                    setApiKey('');
+                    setShowApiKey(false);
+                    setTestStatus('idle');
+                    setTestMessage(null);
+                  }}
+                >
+                  Reset
+                </Button>
+              )}
             </div>
           </form>
         </Card>

--- a/apps/dashboard/lib/api/ai-config.ts
+++ b/apps/dashboard/lib/api/ai-config.ts
@@ -1,32 +1,21 @@
 import { apiRequest } from './client';
+import type {
+  AIProviderType,
+  AiConfigResponse,
+  AIConfigUpdate,
+  ValidateKeyResponse,
+  TestConnectionPayload,
+} from '@/lib/types/ai-config';
 
-export interface AiConfigResponse {
-  configured: boolean;
-  id?: string;
-  tenantId?: string;
-  provider: string;
-  maskedApiKey: string | null;
-  model: string;
-  settings: Record<string, any>;
-  createdAt?: string;
-  updatedAt?: string;
-}
-
-export interface ValidateKeyResponse {
-  valid: boolean;
-  error?: string;
-}
+// Re-export types for convenience
+export type { AIProviderType, AiConfigResponse, AIConfigUpdate, ValidateKeyResponse, TestConnectionPayload };
 
 export const aiConfigApi = {
   getConfig: async (): Promise<AiConfigResponse> => {
     return apiRequest('/api/settings/ai');
   },
 
-  updateConfig: async (data: {
-    apiKey?: string;
-    model?: string;
-    settings?: Record<string, any>;
-  }): Promise<AiConfigResponse> => {
+  updateConfig: async (data: AIConfigUpdate): Promise<AiConfigResponse> => {
     return apiRequest('/api/settings/ai', {
       method: 'PATCH',
       body: JSON.stringify(data),
@@ -37,6 +26,13 @@ export const aiConfigApi = {
     return apiRequest('/api/settings/ai/validate-key', {
       method: 'POST',
       body: JSON.stringify({ apiKey }),
+    });
+  },
+
+  testConnection: async (payload: TestConnectionPayload): Promise<ValidateKeyResponse> => {
+    return apiRequest('/api/system/ai/test', {
+      method: 'POST',
+      body: JSON.stringify(payload),
     });
   },
 };

--- a/apps/dashboard/lib/types/ai-config.ts
+++ b/apps/dashboard/lib/types/ai-config.ts
@@ -1,0 +1,39 @@
+/**
+ * AI Configuration Types
+ */
+
+export type AIProviderType = 'openai' | 'anthropic' | 'ollama';
+
+export interface AiConfigResponse {
+  configured: boolean;
+  id?: string;
+  tenantId?: string;
+  provider: AIProviderType;
+  maskedApiKey: string | null;
+  model: string;
+  settings: Record<string, any>;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export interface AIConfigUpdate {
+  provider?: AIProviderType;
+  apiKey?: string;
+  endpoint?: string;
+  model?: string;
+  organizationId?: string;
+  settings?: Record<string, any>;
+}
+
+export interface ValidateKeyResponse {
+  valid: boolean;
+  error?: string;
+}
+
+export interface TestConnectionPayload {
+  provider: AIProviderType;
+  apiKey?: string;
+  endpoint?: string;
+  model?: string;
+  organizationId?: string;
+}


### PR DESCRIPTION
## Summary
- **AIProvider interface**: Abstract layer with `generateCompletion()`, `generateStructuredOutput()`, `generateEmbedding()`
- **3 providers**: OpenAI (gpt-4o), Anthropic (claude-sonnet-4-5), Ollama (llama3.1 local)
- **AIProviderFactory**: Creates correct provider from tenant config
- **AI config endpoints**: GET/PUT config + POST test connection
- **Dashboard**: Redesigned AI settings with provider cards, dynamic forms, test connection

## Test plan
- [ ] Verify `pnpm build` passes (all 7 packages)
- [ ] Select OpenAI provider, enter key, test connection
- [ ] Select Anthropic provider, enter key, test connection
- [ ] Select Ollama, enter local URL, test connection
- [ ] Verify provider switch persists after page reload

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)